### PR TITLE
[FE] 예약 페이지 첫번째 달력 생성

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -17,7 +17,7 @@ function App() {
         <Provider store={store}>
           <Router />
         </Provider>
-        <Footer prop1={'로고'}/>
+        <Footer prop1={'로고'} />
       </Container>
     </QueryClientProvider>
   );

--- a/client/src/Router.tsx
+++ b/client/src/Router.tsx
@@ -5,9 +5,9 @@ import LoginPage from './pages/Login/views/LoginPage';
 import ItemListPage from './pages/ItemList/views/ItemListPage';
 import DetailPage from './pages/Detail/views/DetailPage';
 import CreatePage from './pages/Create/views/CreatePage';
-import ReservationPage from './pages/Reservation/views/ReservationPage';
 import UpdatePage from './pages/Update/views/UpdatePage';
 import ChattingPage from './pages/Chatting/views/ChattingPage';
+import BookingPage from './pages/Booking/views/BookingPage';
 
 function Router() {
   return (
@@ -16,11 +16,11 @@ function Router() {
         <Route path="/" element={<MainPage />} />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/itemlist" element={<ItemListPage />} />
+        <Route path="/booking" element={<BookingPage />} />
         <Route path="/mypage" element={<MyPage />} />
         <Route path="/detail/:id" element={<DetailPage />} />
         <Route path="/create" element={<CreatePage />} />
         <Route path="/update/:id" element={<UpdatePage />} />
-        <Route path="/reservation" element={<ReservationPage />} />
         <Route path="/chatting" element={<ChattingPage />} />
       </Routes>
     </BrowserRouter>

--- a/client/src/common/store/RootStore.tsx
+++ b/client/src/common/store/RootStore.tsx
@@ -1,8 +1,10 @@
 import { combineReducers, configureStore } from '@reduxjs/toolkit';
 import { userInfo } from './UserInfoStore';
+import { calendar } from '../../pages/Booking/store/CalendarStore';
 
 const rootReducer = combineReducers({
   userInfo: userInfo.reducer,
+  calendar: calendar.reducer,
 });
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/client/src/pages/Booking/components/BookingDates.tsx
+++ b/client/src/pages/Booking/components/BookingDates.tsx
@@ -1,0 +1,22 @@
+import {
+  BookingDatesForm,
+  BookingDatesLabel,
+  DatesInput,
+  DatesWrapper,
+} from '../style';
+
+function BookingDates() {
+  return (
+    <BookingDatesForm>
+      <DatesWrapper>
+        <BookingDatesLabel>예약 시작 날짜</BookingDatesLabel>
+        <DatesInput />
+      </DatesWrapper>
+      <DatesWrapper>
+        <BookingDatesLabel>예약 마감 날짜</BookingDatesLabel>
+        <DatesInput />
+      </DatesWrapper>
+    </BookingDatesForm>
+  );
+}
+export default BookingDates;

--- a/client/src/pages/Booking/components/Calendars.tsx
+++ b/client/src/pages/Booking/components/Calendars.tsx
@@ -1,0 +1,6 @@
+import FirstCalendar from './FirstCalendar';
+
+function Calendars() {
+  return <FirstCalendar />;
+}
+export default Calendars;

--- a/client/src/pages/Booking/components/Dates.tsx
+++ b/client/src/pages/Booking/components/Dates.tsx
@@ -1,0 +1,67 @@
+import { useDispatch, useSelector } from 'react-redux';
+import { DatesContainer, EachDate } from '../style';
+import { RootState } from '../../../common/store/RootStore';
+import { setDate } from '../store/CalendarStore';
+
+function Dates() {
+  const dispatch = useDispatch();
+  const today = useSelector((state: RootState) => state.calendar);
+  const { year, month, date } = today;
+  // 지난 달 마지막 날짜를 구함
+  const lastDateOfLastMonth = new Date(year, month - 1, 0).getDate();
+  // 이번 달 마지막 날짜를 구함
+  const lastDateOfThisMonth = new Date(year, month, 0).getDate();
+  // 이번 달 1일이 무슨 요일인지 구함
+  const firstDayOfThisMonth = new Date(year, month - 1, 1).getDay();
+
+  // 달력 2차원 빈 배열 선언
+  const dates = [...Array(6)].map((_) => [...Array(7)].map(() => 0));
+  dates[0][firstDayOfThisMonth] = 1;
+
+  for (let i = 0; i < dates.length; i++) {
+    if (i === 0) {
+      for (let k = 1; k <= firstDayOfThisMonth; k++) {
+        dates[0][firstDayOfThisMonth - k] = lastDateOfLastMonth - k + 1;
+      }
+    }
+    for (let j = 0; j < 7; j++) {
+      if (dates[i][j]) {
+        continue;
+      }
+      if (dates[i][j - 1]) {
+        dates[i][j] = dates[i][j - 1] + 1;
+      } else if (dates[i - 1]?.[6]) {
+        if (dates[i - 1].includes(lastDateOfThisMonth) && i > 1) break;
+        dates[i][j] = dates[i - 1][6] + 1;
+      }
+
+      if (dates[i][j - 1] === lastDateOfThisMonth) {
+        dates[i][j] = 1;
+      }
+    }
+  }
+
+  const showDates = dates.map((week, i) => (
+    <tr key={i}>
+      {week.map((date, j) => (
+        <EachDate
+          key={j}
+          today={today}
+          row={{
+            week: i,
+            lastWeek: dates.findIndex(
+              (week, index) => index !== 0 && week.includes(1),
+            ),
+          }}
+          day={j}
+          onClick={() => dispatch(setDate({ year, month, date }))}
+        >
+          {date ? date : null}
+        </EachDate>
+      ))}
+    </tr>
+  ));
+
+  return <DatesContainer>{showDates}</DatesContainer>;
+}
+export default Dates;

--- a/client/src/pages/Booking/components/Days.tsx
+++ b/client/src/pages/Booking/components/Days.tsx
@@ -1,0 +1,12 @@
+import { Day, DaysContainer } from '../style';
+
+function Days() {
+  const days = ['일', '월', '화', '수', '목', '금', '토'];
+  const showDays = days.map((day, idx) => <Day key={idx}>{day}</Day>);
+  return (
+    <DaysContainer>
+      <tr>{showDays}</tr>
+    </DaysContainer>
+  );
+}
+export default Days;

--- a/client/src/pages/Booking/components/FirstCalendar.tsx
+++ b/client/src/pages/Booking/components/FirstCalendar.tsx
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+import { YearAndMonthWrapper, Btn, Month, Table, Year } from '../style';
+import Days from './Days';
+import Dates from './Dates';
+
+function FirstCalendar() {
+  const date = new Date();
+  const [year, setYear] = useState(date.getFullYear());
+  const [month, setMonth] = useState(date.getMonth() + 1);
+
+  const onClickBack = () => {
+    if (month > 1) {
+      setMonth(month - 1);
+    } else {
+      setYear(year - 1);
+      setMonth(12);
+    }
+  };
+
+  const onClickNext = () => {
+    if (month < 12) {
+      setMonth(month + 1);
+    } else {
+      setYear(year + 1);
+      setMonth(1);
+    }
+  };
+  return (
+    <Table>
+      <YearAndMonthWrapper>
+        <Btn onClick={onClickBack}>◀️</Btn>
+        <Month>{month + '월'}</Month>
+        <Year>{year}</Year>
+        <Btn onClick={onClickNext}>▶️</Btn>
+      </YearAndMonthWrapper>
+      <Days />
+      <Dates />
+    </Table>
+  );
+}
+
+export default FirstCalendar;

--- a/client/src/pages/Booking/store/CalendarStore.tsx
+++ b/client/src/pages/Booking/store/CalendarStore.tsx
@@ -1,0 +1,30 @@
+import { configureStore, createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+const today = new Date();
+
+type CalendarProps = {
+  year: number;
+  month: number;
+  date: number;
+};
+
+const initialCalendarState: CalendarProps = {
+  year: today.getFullYear(),
+  month: today.getMonth() + 1,
+  date: today.getDate(),
+};
+
+export const calendar = createSlice({
+  name: 'calendarReducer',
+  initialState: initialCalendarState,
+  reducers: {
+    setDate: (state, action: PayloadAction<CalendarProps>) => {
+      state.year = action.payload.year;
+      state.month = action.payload.month;
+      state.date = action.payload.date;
+    },
+  },
+});
+
+export const calendarStore = configureStore({ reducer: calendar.reducer });
+export const { setDate } = calendar.actions;

--- a/client/src/pages/Booking/style.ts
+++ b/client/src/pages/Booking/style.ts
@@ -1,0 +1,139 @@
+import styled from 'styled-components';
+
+export const BookingDatesForm = styled.form`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+  margin-top: 60px;
+  width: 727px;
+  height: 97px;
+  border: 1px solid #ebebeb;
+  border-radius: 50px;
+`;
+
+export const BookingDatesLabel = styled.label`
+  border: 1px solid black;
+`;
+
+export const DatesWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const DatesInput = styled.input`
+  width: 100%;
+  height: 40px;
+`;
+
+export const Table = styled.table`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  border: 1px solid transparent;
+  border-radius: 20px;
+  height: 426px;
+  width: 403px;
+  margin-left: 7vw;
+  box-shadow: 2px 2px 4px #999;
+`;
+
+export const YearAndMonthWrapper = styled.caption`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  position: absolute;
+  margin-bottom: 650px;
+  margin-top: 320px;
+  height: 70px;
+`;
+
+export const Year = styled.span`
+  font-size: 45px;
+  color: black;
+  margin-left: 80px;
+  position: absolute;
+`;
+
+export const MonthWrapper = styled.caption`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  position: absolute;
+  margin-bottom: 500px;
+`;
+
+export const Month = styled.span`
+  font-size: 45px;
+  color: black;
+  padding-bottom: 40px;
+  position: absolute;
+  margin-right: 150px;
+`;
+
+export const Btn = styled.button`
+  background: linear-gradient(200deg, rgba(125, 202, 220, 0.1), #e6cdcd);
+  height: 45px;
+  width: 45px;
+  margin: 10px 13vw;
+  border: rgba(0, 0, 0, 0) 2px solid;
+  border-radius: 100px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const Day = styled.th`
+  font-size: 25px;
+  padding: 20px 0px 20px;
+  width: 50px;
+  color: black;
+`;
+
+export const DaysContainer = styled.thead`
+  position: absolute;
+  width: auto;
+  margin-bottom: 250px;
+`;
+
+export const DatesContainer = styled.tbody`
+  margin-top: 130px;
+`;
+
+export type EachDatesProps = {
+  today: {
+    year: number;
+    month: number;
+    date: number;
+  };
+  row: {
+    week: number;
+    lastWeek: number;
+  };
+  day: number;
+};
+
+export const EachDate = styled.th<EachDatesProps>`
+  font-size: 20px;
+  font-weight: 400;
+  height: 40px;
+  border: 1px solid red;
+  padding: 2px 4.8vw 30px 0.5vw;
+  text-shadow: 1px 1px 2px gray;
+  background-image: ${(props) => {
+    const date = new Date();
+    const thisMonth = date.getMonth();
+    const thisYear = date.getFullYear();
+    return props.today.year === thisYear &&
+      props.today.month === thisMonth &&
+      props.today.date === props.children
+      ? 'linear-gradient(150deg, rgba(249, 245, 245, 0.1),#f3bac3)'
+      : 'linear-gradient(150deg, rgba(244, 239, 239, 0.1), #eae2e4)';
+  }};
+  color: ${(props) => {
+    return (props.row.week === 0 && Number(props.children) > 7) ||
+      (props.row.week === props.row.lastWeek && Number(props.children) < 8)
+      ? 'rgb(0, 0, 0, 0.1)'
+      : 'rgb(0, 0, 0, 0.6)';
+  }};
+`;

--- a/client/src/pages/Booking/views/BookingPage.tsx
+++ b/client/src/pages/Booking/views/BookingPage.tsx
@@ -1,4 +1,12 @@
+import BookingDates from '../components/BookingDates';
+import Calendars from '../components/Calendars';
+
 function BookingPage() {
-  return <div>booking page</div>;
+  return (
+    <>
+      <BookingDates />
+      <Calendars />
+    </>
+  );
 }
 export default BookingPage;

--- a/client/src/pages/Booking/views/BookingPage.tsx
+++ b/client/src/pages/Booking/views/BookingPage.tsx
@@ -1,0 +1,4 @@
+function BookingPage() {
+  return <div>booking page</div>;
+}
+export default BookingPage;

--- a/client/src/pages/Reservation/views/ReservationPage.tsx
+++ b/client/src/pages/Reservation/views/ReservationPage.tsx
@@ -1,4 +1,0 @@
-function ReservationPage() {
-  return <div>reservation page</div>;
-}
-export default ReservationPage;


### PR DESCRIPTION
### 기능 요약
[이번 달 달력 생성]
- 지난 달, 다음 달로 넘어갈 수 있는 버튼 생성 (useState으로 상태 관리)
- 지난 달 마지막 날짜, 이번 달 마지막 날짜, 이번 달 1일의 요일을 구하여 달력 알고리즘 구현
- table tag 사용하여 날짜를 표에 나타냄
- 유저가 클릭한 날짜 상태를 보관하는 store 생성

### 화면/테스트 결과
![스크린샷 2023-07-06 오전 8 52 43](https://github.com/codestates-seb/seb44_main_028/assets/117507731/7ac1af68-5451-4d06-91d2-f01d0008facb)


### 배운점
- 처음에 유저가 클릭한 연도와 월의 상태를 redux store로 관리하려고 했었는데, 복잡하지 않은 상태는 useState을 사용하는 것이 관리 측면에서 더 좋겠다는 멘토님의 조언을 반영하였다.