### PR TITLE
[BE] 카카오 oauth 구현 v2 - redirection 로직 구현 

### DIFF
--- a/server/src/main/java/com/ftiland/travelrental/member/dto/GetMember.java
+++ b/server/src/main/java/com/ftiland/travelrental/member/dto/GetMember.java
@@ -1,0 +1,40 @@
+package com.ftiland.travelrental.member.dto;
+
+import com.ftiland.travelrental.category.dto.CategoryDto;
+import com.ftiland.travelrental.member.entity.Member;
+import com.ftiland.travelrental.product.dto.CreateProduct;
+import com.ftiland.travelrental.product.entity.Product;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class GetMember {
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Response {
+
+        private Long memberId;
+        private String email;
+        private String displayName;
+
+        // 이미지 필드 필요
+
+        private Double latitude;
+        private Double longitude;
+
+        public static GetMember.Response from(Member member) {
+            return Response.builder()
+                    .memberId(member.getMemberId())
+                    .email(member.getEmail())
+                    .displayName(member.getDisplayName())
+                    .longitude(member.getLongitude())
+                    .latitude(member.getLatitude())
+                    .build();
+        }
+    }
+}

--- a/server/src/main/java/com/ftiland/travelrental/member/entity/Member.java
+++ b/server/src/main/java/com/ftiland/travelrental/member/entity/Member.java
@@ -23,15 +23,16 @@ public class Member extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long memberId;
     private String email;
-    private String name;
+    private String displayName;
 
     // 이미지 필드 필요
 
     private Double latitude;
     private Double longitude;
 
-    public Member(String email) {
+    public Member(String email, String displayName) {
         this.email = email;
+        this.displayName = displayName;
     }
 
 /*    private Double totalRateScore;

--- a/server/src/main/java/com/ftiland/travelrental/member/service/MemberService.java
+++ b/server/src/main/java/com/ftiland/travelrental/member/service/MemberService.java
@@ -1,6 +1,8 @@
 package com.ftiland.travelrental.member.service;
 
 
+import com.ftiland.travelrental.common.exception.BusinessLogicException;
+import com.ftiland.travelrental.common.exception.ExceptionCode;
 import com.ftiland.travelrental.member.entity.Member;
 import com.ftiland.travelrental.member.repository.MemberRepository;
 import org.springframework.stereotype.Service;
@@ -24,8 +26,21 @@ public class MemberService {
         return null;
     }
 
+    public Member getMember(Long memberId) {
+        return findVerfiedMember(memberId);
+    }
+
     private boolean existsEmail(String email) {
         Optional<Member> member = memberRepository.findByEmail(email);
         return member.isPresent();
     }
+
+    private Member findVerfiedMember(Long id) {
+        Optional<Member> optionalMember = memberRepository.findById(id);
+        Member findMember = optionalMember.orElseThrow(() ->
+                    new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND)
+                );
+        return findMember;
+    }
+
 }

--- a/server/src/main/java/com/ftiland/travelrental/oauth/auth/controller/authController.java
+++ b/server/src/main/java/com/ftiland/travelrental/oauth/auth/controller/authController.java
@@ -1,0 +1,35 @@
+package com.ftiland.travelrental.oauth.auth.controller;
+
+import com.ftiland.travelrental.member.dto.GetMember;
+import com.ftiland.travelrental.member.entity.Member;
+import com.ftiland.travelrental.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequestMapping("/api/members")
+@RestController
+@RequiredArgsConstructor
+public class authController {
+    private final MemberService memberService;
+
+    @GetMapping("/me")
+    public ResponseEntity<GetMember.Response> getMember() {
+        org.springframework.security.core.userdetails.User principal = (org.springframework.security.core.userdetails.User)
+                SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        System.out.println(principal.toString());
+        Long memberId = 1L;
+
+        Member member = memberService.getMember(memberId);
+
+        GetMember.Response response = GetMember.Response.from(member);
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+}

--- a/server/src/main/java/com/ftiland/travelrental/oauth/auth/handler/Oauth2MemberSuccessHandler.java
+++ b/server/src/main/java/com/ftiland/travelrental/oauth/auth/handler/Oauth2MemberSuccessHandler.java
@@ -3,7 +3,7 @@ package com.ftiland.travelrental.oauth.auth.handler;
 import com.ftiland.travelrental.member.entity.Member;
 import com.ftiland.travelrental.member.service.MemberService;
 import com.ftiland.travelrental.oauth.jwt.JwtTokenizer;
-import org.springframework.data.querydsl.binding.MultiValueBinding;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
@@ -12,14 +12,12 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.URI;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class Oauth2MemberSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
     private final JwtTokenizer jwtTokenizer;
@@ -39,29 +37,62 @@ public class Oauth2MemberSuccessHandler extends SimpleUrlAuthenticationSuccessHa
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         var oAuth2User = (OAuth2User)authentication.getPrincipal();
-        String email = String.valueOf(oAuth2User.getAttributes().get("email"));
-        saveMember(email);
-        redirect(request, response, email);
+        Map<String, Object> kakaoAccount = (Map<String, Object>)oAuth2User.getAttribute("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+
+        String email = String.valueOf(kakaoAccount.get("email"));
+        String displayName = (String) profile.get("nickname");
+
+        Member savedMember = saveMember(email, displayName);
+        Long memberId = savedMember.getMemberId();
+
+        String accessToken = delegateAccessToken(displayName, memberId, email);
+        String refreshToken = delegateRefreshToken(displayName);
+
+        response.addHeader("Authorization", "Bearer " + accessToken);
+        Cookie refreshTokenCookie = new Cookie("refreshToken", refreshToken);
+        refreshTokenCookie.setSecure(true);
+        refreshTokenCookie.setHttpOnly(true);
+        refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setMaxAge(30 * 24 * 60 * 60);
+        response.addCookie(refreshTokenCookie);
+
+        String host = "http://localhost:3000";
+        getRedirectStrategy().sendRedirect(request, response, host);
+//        String uri = createURI(accessToken, refreshToken, host).toString();
+//        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+//        response.setCharacterEncoding("UTF-8");
+//        response.getWriter().write("{\"message\": \"로그인 성공\"}");
+
+//        super.onAuthenticationSuccess(request, response, authentication);
+//        redirect(request, response, displayName, memberId, email);
     }
 
-    private void saveMember(String email) {
-        Member member = new Member(email);
-        memberService.createMember(member);
+    private Member saveMember(String email, String displayName) {
+        Member member = new Member(email, displayName);
+        Member savedMember = memberService.createMember(member);
+
+        return savedMember;
     }
 
-    private void redirect(HttpServletRequest request, HttpServletResponse response, String username) throws IOException {
-        String accessToken = delegateAccessToken(username);
-        String refreshToken = delegateRefreshToken(username);
+    private void redirect(HttpServletRequest request, HttpServletResponse response, String displayName, Long memberId, String email) throws IOException {
+        String accessToken = delegateAccessToken(displayName, memberId, email);
+        String refreshToken = delegateRefreshToken(displayName);
 
-        String uri = createURI(accessToken, refreshToken).toString();
-        getRedirectStrategy().sendRedirect(request, response, uri);
+        response.addHeader("Authorization", "Bearer" + accessToken);
+        Cookie refreshTokenCookie = new Cookie("refreshToken", refreshToken);
+
+//        String uri = createURI(accessToken, refreshToken).toString();
+//        getRedirectStrategy().sendRedirect(request, response, uri);
     }
 
-    private String delegateAccessToken(String username) {
+    private String delegateAccessToken(String displayName, Long memberId, String email) {
         Map<String, Object> claims = new HashMap<>();
-        claims.put("username", username);
+        claims.put("memberId", memberId);
+        claims.put("displayName", displayName);
+        claims.put("email", email);
 
-        String subject = username;
+        String subject = displayName;
         Date expiration = jwtTokenizer.getTokenExpiration(jwtTokenizer.getAccessTokenExpirationMinutes());
         String base64EncodedSecretKey = jwtTokenizer.encodeBase64SecretKey(jwtTokenizer.getSecretKey());
 
@@ -72,8 +103,8 @@ public class Oauth2MemberSuccessHandler extends SimpleUrlAuthenticationSuccessHa
         return accessToken;
     }
 
-    private String delegateRefreshToken(String username) {
-        String subject = username;
+    private String delegateRefreshToken(String displayName) {
+        String subject = displayName;
         Date expiration = jwtTokenizer.getTokenExpiration(jwtTokenizer.getRefreshTokenExpirationMinutes());
         String base64EncodedSecretKey = jwtTokenizer.encodeBase64SecretKey(jwtTokenizer.getSecretKey());
         String refreshToken = jwtTokenizer.generateRefreshToken(subject, expiration, base64EncodedSecretKey);
@@ -81,7 +112,7 @@ public class Oauth2MemberSuccessHandler extends SimpleUrlAuthenticationSuccessHa
         return refreshToken;
     }
 
-    private URI createURI(String accessToken, String refreshToken) {
+    private URI createURI(String accessToken, String refreshToken, String host) {
         MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         queryParams.add("access_token", accessToken);
         queryParams.add("refresh_token", refreshToken);
@@ -89,8 +120,7 @@ public class Oauth2MemberSuccessHandler extends SimpleUrlAuthenticationSuccessHa
         return UriComponentsBuilder
                 .newInstance()
                 .scheme("http")
-                .host("localhost")
-                .path("/receive-token.html")
+                .host(host)
                 .queryParams(queryParams)
                 .build()
                 .toUri();

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -19,6 +19,7 @@ spring:
             client-name: Kakao
             scope:
               - account_email
+              - profile_nickname
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize


### PR DESCRIPTION
### 기능 요약
- 카카오와 맞춰서 객체이름 수정
- 컨트롤러 생성
- id로 유저 가져올 수 있도록 수정
- 토큰을 헤더와 쿠키에 넣는 것으로 변경

### 배운점
oauth의 다양한 방식에 대해서 생각해 볼 수 있는 기회였다.