### PR TITLE
[FE] Loading 컴포넌트 구현

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -27,6 +27,7 @@
         "react-redux": "^8.1.0",
         "react-router-dom": "^6.13.0",
         "react-scripts": "5.0.1",
+        "react-spinners": "^0.13.8",
         "redux": "^4.2.1",
         "styled-components": "^5.3.11",
         "typescript": "^4.9.5",
@@ -15239,6 +15240,15 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-spinners": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.13.8.tgz",
+      "integrity": "sha512-3e+k56lUkPj0vb5NDXPVFAOkPC//XyhKPJjvcGjyMNPWsBKpplfeyialP74G7H7+It7KzhtET+MvGqbKgAqpZA==",
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-transition-group": {

--- a/client/package.json
+++ b/client/package.json
@@ -22,6 +22,7 @@
     "react-redux": "^8.1.0",
     "react-router-dom": "^6.13.0",
     "react-scripts": "5.0.1",
+    "react-spinners": "^0.13.8",
     "redux": "^4.2.1",
     "styled-components": "^5.3.11",
     "typescript": "^4.9.5",

--- a/client/src/common/components/Loading.tsx
+++ b/client/src/common/components/Loading.tsx
@@ -1,0 +1,13 @@
+import { BeatLoader } from 'react-spinners';
+import { LoadingWrapper } from '../style/style';
+import { colorPalette } from '../utils/enum/colorPalette';
+
+const Loading = () => {
+  return (
+    <LoadingWrapper>
+      <BeatLoader color={`${colorPalette.loadingColor}`} size={25} />
+    </LoadingWrapper>
+  );
+};
+
+export default Loading;

--- a/client/src/common/style/style.ts
+++ b/client/src/common/style/style.ts
@@ -4,7 +4,6 @@ import { colorPalette } from '../utils/enum/colorPalette';
 import { fontSize } from '../utils/enum/fontSize';
 import { border } from '../utils/enum/border';
 
-
 // Modal 컴포넌트의 스타일을 정의
 export const CategoryContainer = styled.div`
   display: grid;
@@ -235,4 +234,12 @@ export const Option = styled.li`
   &:hover {
     background-color: ${colorPalette.selectListHoverColor};
   }
+`;
+// Loading 컴포넌트의 스타일을 정의
+export const LoadingWrapper = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 100;
 `;

--- a/client/src/common/utils/enum/colorPalette.ts
+++ b/client/src/common/utils/enum/colorPalette.ts
@@ -14,4 +14,5 @@ export enum colorPalette {
   modalCancelButtonColor = '#CDDBF0',
   itemCardHeartColor = '#DEDEDE',
   selectListHoverColor = '#F2F7FF',
+  loadingColor = '#00ffcc',
 }


### PR DESCRIPTION
### 기능 요약
- `react-spinners` 라이브러리를 설치 후 로딩 컴포넌트 구현

### 화면/테스트 결과
![Jul-08-2023 19-44-39](https://github.com/codestates-seb/seb44_main_028/assets/72354092/42abe654-57e9-4047-8d8d-e4b031c14330)

### 배운점
- `styled-components`를 사용하여 스타일을 지정하려고 하니 작동하지 않았습니다.
```ts
 <BeatLoader color={`${colorPalette.loadingColor}`} size={25} />
 ```
- 위의 방식으로 인라인으로 지정하여 스타일을 지정할 수 있었습니다.