### PR TITLE
[FE] 카카오 로그인 access token 요청 및 웹 스토리지 저장 로직 추가/달력 예약 날짜 UI 작업(시작 날짜, 마감 날짜의 연도가 같은 경우)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,12 +13,12 @@ function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <Header />
-      <Container maxWidth="xs">
+      <Container maxWidth="lg">
         <Provider store={store}>
           <Router />
         </Provider>
-        <Footer prop1={'플레이 팩'} />
       </Container>
+      <Footer prop1={'플레이 팩'} />
     </QueryClientProvider>
   );
 }

--- a/client/src/Router.tsx
+++ b/client/src/Router.tsx
@@ -15,12 +15,12 @@ function Router() {
       <Routes>
         <Route path="/" element={<MainPage />} />
         <Route path="/login" element={<LoginPage />} />
-        <Route path="/itemlist" element={<ItemListPage />} />
-        <Route path="/booking" element={<BookingPage />} />
+        <Route path="/itemlist/:categoryId" element={<ItemListPage />} />
+        <Route path="/booking/:itemId" element={<BookingPage />} />
         <Route path="/mypage" element={<MyPage />} />
-        <Route path="/detail/:id" element={<DetailPage />} />
+        <Route path="/detail/:itemId" element={<DetailPage />} />
         <Route path="/create" element={<CreatePage />} />
-        <Route path="/update/:id" element={<UpdatePage />} />
+        <Route path="/update/:itemId" element={<UpdatePage />} />
         <Route path="/chatting" element={<ChattingPage />} />
       </Routes>
     </BrowserRouter>

--- a/client/src/common/style/style.ts
+++ b/client/src/common/style/style.ts
@@ -4,7 +4,6 @@ import { colorPalette } from '../utils/enum/colorPalette';
 import { fontSize } from '../utils/enum/fontSize';
 import { border } from '../utils/enum/border';
 
-
 // Modal 컴포넌트의 스타일을 정의
 export const CategoryContainer = styled.div`
   display: grid;

--- a/client/src/pages/Booking/components/BookingDates.tsx
+++ b/client/src/pages/Booking/components/BookingDates.tsx
@@ -2,28 +2,44 @@ import { useSelector } from 'react-redux';
 import {
   BookingDatesForm,
   BookingDatesLabel,
-  DatesInput,
   DatesWrapper,
+  ReservationDate,
 } from '../style';
 import { RootState } from '../../../common/store/RootStore';
 
 function BookingDates() {
-  const reservationState = useSelector((state: RootState) => state.reservation);
+  const reservationStartDate = useSelector(
+    (state: RootState) => state.reservation.startDate,
+  );
+  const reservationEndDate = useSelector(
+    (state: RootState) => state.reservation.endDate,
+  );
+
+  const fillZero = (number: number) => {
+    return String(number).padStart(2, '0');
+  };
+
   return (
     <BookingDatesForm>
       <DatesWrapper>
         <BookingDatesLabel>예약 시작 날짜</BookingDatesLabel>
-        <DatesInput />
-        {reservationState.startDate
-          ? `${reservationState.startDate?.year}/${reservationState.startDate?.month}/${reservationState.startDate?.date}`
-          : null}
+        <ReservationDate>
+          {reservationStartDate
+            ? `${reservationStartDate?.year}.${fillZero(
+                reservationStartDate?.month,
+              )}.${fillZero(reservationStartDate?.date)}`
+            : null}
+        </ReservationDate>
       </DatesWrapper>
       <DatesWrapper>
         <BookingDatesLabel>예약 마감 날짜</BookingDatesLabel>
-        <DatesInput />
-        {reservationState.endDate
-          ? `${reservationState.endDate?.year}/${reservationState.endDate?.month}/${reservationState.endDate?.date}`
-          : null}
+        <ReservationDate>
+          {reservationEndDate
+            ? `${reservationEndDate?.year}.${fillZero(
+                reservationEndDate?.month,
+              )}.${fillZero(reservationEndDate?.date)}`
+            : null}
+        </ReservationDate>
       </DatesWrapper>
     </BookingDatesForm>
   );

--- a/client/src/pages/Booking/components/BookingDates.tsx
+++ b/client/src/pages/Booking/components/BookingDates.tsx
@@ -4,6 +4,7 @@ import {
   BookingDatesLabel,
   DatesWrapper,
   ReservationDate,
+  SeparationLine,
 } from '../style';
 import { RootState } from '../../../common/store/RootStore';
 
@@ -31,6 +32,7 @@ function BookingDates() {
             : null}
         </ReservationDate>
       </DatesWrapper>
+      <SeparationLine>|</SeparationLine>
       <DatesWrapper>
         <BookingDatesLabel>예약 마감 날짜</BookingDatesLabel>
         <ReservationDate>

--- a/client/src/pages/Booking/components/Dates.tsx
+++ b/client/src/pages/Booking/components/Dates.tsx
@@ -10,35 +10,37 @@ function Dates({ calendar }: CalendarProps) {
 
   const { year, month, date } = calendar;
   // 지난 달 마지막 날짜를 구함
-  const lastDateOfLastMonth = new Date(year, month - 1, 0).getDate();
+  // const lastDateOfLastMonth: number = new Date(year, month - 1, 0).getDate();
   // 이번 달 마지막 날짜를 구함
-  const lastDateOfThisMonth = new Date(year, month, 0).getDate();
+  const lastDateOfThisMonth: number = new Date(year, month, 0).getDate();
   // 이번 달 1일이 무슨 요일인지 구함
-  const firstDayOfThisMonth = new Date(year, month - 1, 1).getDay();
+  const firstDayOfThisMonth: number = new Date(year, month - 1, 1).getDay();
 
   // 달력 2차원 빈 배열 선언
-  const dates = [...Array(6)].map((_) => [...Array(7)].map(() => 0));
+  const dates: number[][] = [...Array(6)].map((_) =>
+    [...Array(7)].map(() => 0),
+  );
   dates[0][firstDayOfThisMonth] = 1;
 
   for (let i = 0; i < dates.length; i++) {
-    if (i === 0) {
-      for (let k = 1; k <= firstDayOfThisMonth; k++) {
-        dates[0][firstDayOfThisMonth - k] = lastDateOfLastMonth - k + 1;
-      }
-    }
+    // if (i === 0) {
+    //   for (let k = 1; k <= firstDayOfThisMonth; k++) {
+    //     dates[0][firstDayOfThisMonth - k] = lastDateOfLastMonth - k + 1;
+    //   }
+    // }
     for (let j = 0; j < 7; j++) {
-      if (dates[i][j]) {
-        continue;
-      }
+      // if (dates[i][j]) {
+      //   continue;
+      // }
       if (dates[i][j - 1]) {
         dates[i][j] = dates[i][j - 1] + 1;
       } else if (dates[i - 1]?.[6]) {
-        if (dates[i - 1].includes(lastDateOfThisMonth) && i > 1) break;
+        // if (dates[i - 1].includes(lastDateOfThisMonth) && i > 1) break;
         dates[i][j] = dates[i - 1][6] + 1;
       }
 
-      if (dates[i][j - 1] === lastDateOfThisMonth) {
-        dates[i][j] = 1;
+      if (dates[i][j] === lastDateOfThisMonth) {
+        break;
       }
     }
   }

--- a/client/src/pages/Booking/components/Dates.tsx
+++ b/client/src/pages/Booking/components/Dates.tsx
@@ -34,8 +34,12 @@ function Dates({ calendar }: CalendarProps) {
       // }
       if (dates[i][j - 1]) {
         dates[i][j] = dates[i][j - 1] + 1;
+        if (dates[i][j] === lastDateOfThisMonth) {
+          break;
+        }
       } else if (dates[i - 1]?.[6]) {
-        // if (dates[i - 1].includes(lastDateOfThisMonth) && i > 1) break;
+        if (dates[i - 1].includes(lastDateOfThisMonth) && i > 1) break;
+
         dates[i][j] = dates[i - 1][6] + 1;
       }
 

--- a/client/src/pages/Booking/store/ReservationDateStore.tsx
+++ b/client/src/pages/Booking/store/ReservationDateStore.tsx
@@ -16,7 +16,7 @@ export const reservation = createSlice({
   reducers: {
     setStartDate: (state, action: PayloadAction<ReservationProps>) => {
       const newStart = action.payload.startDate;
-      if (!newStart) return;
+      if (!newStart || !newStart.date) return;
 
       const newStartYear = newStart.year;
       const newStartMonth = newStart.month;
@@ -39,7 +39,7 @@ export const reservation = createSlice({
     },
     setEndDate: (state, action: PayloadAction<ReservationProps>) => {
       const newEnd = action.payload.endDate;
-      if (!newEnd) return;
+      if (!newEnd || !newEnd.date) return;
 
       const newEndYear = newEnd.year;
       const newEndMonth = newEnd.month;

--- a/client/src/pages/Booking/store/ReservationDateStore.tsx
+++ b/client/src/pages/Booking/store/ReservationDateStore.tsx
@@ -15,15 +15,28 @@ export const reservation = createSlice({
   initialState: initialReservationState,
   reducers: {
     setStartDate: (state, action: PayloadAction<ReservationProps>) => {
-      state.startDate = action.payload.startDate;
+      const today = new Date();
+      if (
+        action.payload.startDate &&
+        action.payload.startDate?.year >= today.getFullYear() &&
+        action.payload.startDate?.month >= today.getMonth() + 1 &&
+        action.payload.startDate?.date >= today.getDate()
+      ) {
+        state.startDate = action.payload.startDate;
+      } else {
+        return;
+      }
     },
     setEndDate: (state, action: PayloadAction<ReservationProps>) => {
       if (
         state.startDate &&
         action.payload.endDate &&
-        state.startDate.year <= action.payload.endDate?.year &&
-        state.startDate.month <= action.payload.endDate?.month &&
-        state.startDate.date <= action.payload.endDate?.date
+        (state.startDate.year < action.payload.endDate?.year ||
+          (state.startDate.year === action.payload.endDate?.year &&
+            state.startDate.month < action.payload.endDate?.month) ||
+          (state.startDate.year === action.payload.endDate?.year &&
+            state.startDate.month === action.payload.endDate?.month &&
+            state.startDate.date <= action.payload.endDate?.date))
       ) {
         state.endDate = action.payload.endDate;
       } else {

--- a/client/src/pages/Booking/store/ReservationDateStore.tsx
+++ b/client/src/pages/Booking/store/ReservationDateStore.tsx
@@ -15,32 +15,50 @@ export const reservation = createSlice({
   initialState: initialReservationState,
   reducers: {
     setStartDate: (state, action: PayloadAction<ReservationProps>) => {
+      const newStart = action.payload.startDate;
+      if (!newStart) return;
+
+      const newStartYear = newStart.year;
+      const newStartMonth = newStart.month;
+      const newStartDate = newStart.date;
+
       const today = new Date();
+      const todaysYear = today.getFullYear();
+      const todaysMonth = today.getMonth() + 1;
+      const todaysDate = today.getDate();
+
       if (
-        action.payload.startDate &&
-        action.payload.startDate?.year >= today.getFullYear() &&
-        action.payload.startDate?.month >= today.getMonth() + 1 &&
-        action.payload.startDate?.date >= today.getDate()
+        newStartYear > todaysYear ||
+        (newStartYear === todaysYear && newStartMonth > todaysMonth) ||
+        (newStartYear === todaysYear &&
+          newStartMonth === todaysMonth &&
+          newStartDate >= todaysDate)
       ) {
-        state.startDate = action.payload.startDate;
-      } else {
-        return;
+        state.startDate = newStart;
       }
     },
     setEndDate: (state, action: PayloadAction<ReservationProps>) => {
+      const newEnd = action.payload.endDate;
+      if (!newEnd) return;
+
+      const newEndYear = newEnd.year;
+      const newEndMonth = newEnd.month;
+      const newEndDate = newEnd.date;
+
+      const currentStart = state.startDate;
+      if (!currentStart) return;
+      const currentStartYear = currentStart.year;
+      const currentStartMonth = currentStart.month;
+      const currentStartDate = currentStart.date;
+
       if (
-        state.startDate &&
-        action.payload.endDate &&
-        (state.startDate.year < action.payload.endDate?.year ||
-          (state.startDate.year === action.payload.endDate?.year &&
-            state.startDate.month < action.payload.endDate?.month) ||
-          (state.startDate.year === action.payload.endDate?.year &&
-            state.startDate.month === action.payload.endDate?.month &&
-            state.startDate.date <= action.payload.endDate?.date))
+        currentStartYear < newEndYear ||
+        (currentStartYear === newEndYear && currentStartMonth < newEndMonth) ||
+        (currentStartYear === newEndYear &&
+          currentStartMonth === newEndMonth &&
+          currentStartDate <= newEndDate)
       ) {
-        state.endDate = action.payload.endDate;
-      } else {
-        return;
+        state.endDate = newEnd;
       }
     },
     clearReservationDates: () => {

--- a/client/src/pages/Booking/style.ts
+++ b/client/src/pages/Booking/style.ts
@@ -30,6 +30,8 @@ export const CalendarWrapper = styled.div`
   display: flex;
   flex-direction: row;
   margin: 30px;
+  border-radius: 20px;
+  box-shadow: 2px 2px 5px #999;
 `;
 
 export const BookingDatesForm = styled.form`
@@ -69,7 +71,6 @@ export const Table = styled.table`
   border-radius: 20px;
   height: 426px;
   width: 403px;
-  box-shadow: 2px 2px 4px #999;
 `;
 
 export const YearAndMonthWrapper = styled.caption`
@@ -163,4 +164,11 @@ export const EachDate = styled.th<EachDatesProps>`
       ? 'not-allowed'
       : 'pointer';
   }};
+`;
+
+export const SeparationLine = styled.span`
+  position: absolute;
+  font-size: 70px;
+  font-weight: 300;
+  color: rgba(0, 0, 0, 0.1);
 `;

--- a/client/src/pages/Booking/style.ts
+++ b/client/src/pages/Booking/style.ts
@@ -79,10 +79,8 @@ export const YearAndMonthWrapper = styled.caption`
   display: flex;
   flex-direction: row;
   justify-content: center;
-  position: absolute;
-  margin-bottom: 650px;
-  margin-top: 350px;
-  height: 70px;
+  position: relative;
+  margin-top: 20px;
 `;
 
 export const Year = styled.span`
@@ -128,7 +126,7 @@ export const Day = styled.th`
 export const DaysContainer = styled.thead`
   position: absolute;
   width: auto;
-  margin-bottom: 250px;
+  margin-bottom: 205px;
 `;
 
 export const DatesContainer = styled.tbody`

--- a/client/src/pages/Booking/style.ts
+++ b/client/src/pages/Booking/style.ts
@@ -1,5 +1,8 @@
 import styled from 'styled-components';
 import { EachDatesProps } from './type';
+import { useSelector } from 'react-redux';
+import { RootState } from '../../common/store/RootStore';
+import { colorPalette } from '../../common/utils/enum/colorPalette';
 
 export const BookingPageContainer = styled.div`
   display: flex;
@@ -164,6 +167,41 @@ export const EachDate = styled.th<EachDatesProps>`
       Number(props.children) === 0
       ? 'default'
       : 'pointer';
+  }};
+  background-color: ${(props) => {
+    const start = useSelector(
+      (state: RootState) => state.reservation.startDate,
+    );
+    const end = useSelector((state: RootState) => state.reservation.endDate);
+
+    const startYear = start?.year;
+    const startMonth = start?.month;
+    const startDate = start?.date;
+
+    const endYear = end?.year;
+    const endMonth = end?.month;
+    const endDate = end?.date;
+
+    if (start && !end) {
+      return startYear === props.today.year &&
+        startMonth === props.today.month &&
+        startDate === Number(props.children)
+        ? colorPalette.deepMintColor
+        : 'white';
+    }
+
+    if (startDate && endDate) {
+      if (startYear === endYear) {
+        if (startMonth === endMonth) {
+          return startYear === props.today.year &&
+            startMonth === props.today.month &&
+            startDate <= Number(props.children) &&
+            endDate >= Number(props.children)
+            ? colorPalette.deepMintColor
+            : 'white';
+        }
+      }
+    }
   }};
 `;
 

--- a/client/src/pages/Booking/style.ts
+++ b/client/src/pages/Booking/style.ts
@@ -160,8 +160,9 @@ export const EachDate = styled.th<EachDatesProps>`
         props.today.month < thisMonth) ||
       (props.today.year === new Date().getFullYear() &&
         props.today.month === thisMonth &&
-        props.today.date > Number(props.children))
-      ? 'not-allowed'
+        props.today.date > Number(props.children)) ||
+      Number(props.children) === 0
+      ? 'default'
       : 'pointer';
   }};
 `;

--- a/client/src/pages/Booking/style.ts
+++ b/client/src/pages/Booking/style.ts
@@ -6,28 +6,37 @@ export const BookingPageContainer = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  margin-bottom: 1000px;
 `;
 
 export const CalendarContainer = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
+  width: 807px;
 `;
 
 export const ButtonWrapper = styled.div`
+  position: absolute;
   display: flex;
   flex-direction: row;
+  justify-content: space-between;
+  width: 1000px;
+  margin-top: 50px;
 `;
+
 export const CalendarWrapper = styled.div`
   display: flex;
   flex-direction: row;
+  margin: 30px;
 `;
 
 export const BookingDatesForm = styled.form`
   display: flex;
   flex-direction: row;
   justify-content: space-around;
+  align-items: center;
   margin-top: 60px;
   width: 727px;
   height: 97px;
@@ -36,17 +45,20 @@ export const BookingDatesForm = styled.form`
 `;
 
 export const BookingDatesLabel = styled.label`
-  border: 1px solid black;
+  font-weight: 600;
 `;
 
 export const DatesWrapper = styled.div`
   display: flex;
   flex-direction: column;
+  justify-content: center;
+  align-items: center;
 `;
 
-export const DatesInput = styled.input`
-  width: 100%;
-  height: 40px;
+export const ReservationDate = styled.h6`
+  font-size: 20px;
+  font-weight: 300;
+  margin-top: 10px;
 `;
 
 export const Table = styled.table`
@@ -66,14 +78,14 @@ export const YearAndMonthWrapper = styled.caption`
   justify-content: center;
   position: absolute;
   margin-bottom: 650px;
-  margin-top: 320px;
+  margin-top: 350px;
   height: 70px;
 `;
 
 export const Year = styled.span`
-  font-size: 30px;
+  font-size: 20px;
   color: black;
-  margin-left: 80px;
+  margin-left: 40px;
   position: absolute;
 `;
 
@@ -86,30 +98,28 @@ export const MonthWrapper = styled.caption`
 `;
 
 export const Month = styled.span`
-  font-size: 30px;
+  font-size: 20px;
   color: black;
   padding-bottom: 40px;
   position: absolute;
-  margin-right: 150px;
+  margin-right: 70px;
   width: 100px;
 `;
 
 export const Btn = styled.button`
+  position: relative;
   height: 45px;
   width: 45px;
-  margin: 10px 13vw;
-  border: rgba(0, 0, 0, 0) 2px solid;
   border-radius: 100px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  border: none;
 `;
 
 export const Day = styled.th`
-  font-size: 25px;
+  font-size: 20px;
   padding: 20px 0px 20px;
-  width: 50px;
+  width: 44px;
   color: black;
+  font-weight: 450;
 `;
 
 export const DaysContainer = styled.thead`
@@ -126,7 +136,7 @@ export const EachDate = styled.th<EachDatesProps>`
   font-size: 20px;
   font-weight: 400;
   height: 20px;
-  padding: 14px;
+  padding: 11px;
   color: ${(props) => {
     const thisMonth = new Date().getMonth() + 1;
     return (props.row.week === 0 && Number(props.children) > 7) ||

--- a/client/src/pages/Booking/style.ts
+++ b/client/src/pages/Booking/style.ts
@@ -39,11 +39,13 @@ export const BookingDatesForm = styled.form`
   flex-direction: row;
   justify-content: space-around;
   align-items: center;
-  margin-top: 60px;
+  margin-top: 30px;
+  padding-top: 5px;
   width: 727px;
   height: 97px;
-  border: 1px solid #ebebeb;
+  border: 1px solid rgba(0, 0, 0, 0.1);
   border-radius: 50px;
+  box-shadow: 1px 1px 3px #999;
 `;
 
 export const BookingDatesLabel = styled.label`

--- a/client/src/pages/Booking/style.ts
+++ b/client/src/pages/Booking/style.ts
@@ -199,6 +199,23 @@ export const EachDate = styled.th<EachDatesProps>`
             endDate >= Number(props.children)
             ? colorPalette.deepMintColor
             : 'white';
+        } else {
+          return ((startYear === props.today.year &&
+            startMonth === props.today.month &&
+            startDate <= Number(props.children)) ||
+            (endYear === props.today.year &&
+              endMonth === props.today.month &&
+              endDate >= Number(props.children))) &&
+            Number(props.children) !== 0
+            ? colorPalette.deepMintColor
+            : startMonth &&
+              endMonth &&
+              endMonth - startMonth > 1 &&
+              props.today.month > startMonth &&
+              props.today.month < endMonth &&
+              Number(props.children) !== 0
+            ? colorPalette.deepMintColor
+            : 'white';
         }
       }
     }

--- a/client/src/pages/Booking/views/BookingPage.tsx
+++ b/client/src/pages/Booking/views/BookingPage.tsx
@@ -1,3 +1,4 @@
+import { DefaultBtn } from '../../../common/style/style';
 import BookingDates from '../components/BookingDates';
 import Calendars from '../components/Calendars';
 import { BookingPageContainer } from '../style';
@@ -7,6 +8,7 @@ function BookingPage() {
     <BookingPageContainer>
       <BookingDates />
       <Calendars />
+      <DefaultBtn>예약하기</DefaultBtn>
     </BookingPageContainer>
   );
 }

--- a/client/src/pages/Footer/FooterStyles.ts
+++ b/client/src/pages/Footer/FooterStyles.ts
@@ -4,7 +4,7 @@ import { colorPalette } from '../../common/utils/enum/colorPalette';
 export const FooterWrapper = styled.div`
   display: flex;
   justify-content: space-between;
-  position: absolute;
+  position: fixed;
   bottom: 0;
   width: 100%;
   height: 70px;


### PR DESCRIPTION
### 기능 요약
[카카오 로그인 로직 변경 사항 반영]
- 인가 코드를 POST 요청에 담아 access token을 응답으로 받는 로직 구현 (React-Query 사용)
- 웹 스토리지에 암호화하여 저장하는 로직 구현 (CryptoJS 사용하여 암호화/복호화 custom hook 생성 및 적용)

[예약 날짜 달력 UI 작업]
- fillZero 함수 생성 및 적용(월과 일이 항상 2자리가 되도록 padStart 사용)
- 달력 버그 수정
: 마감 날짜 클릭 시 간혹 화면에 반영이 안되는 버그 해결
: 연도가 다를 때 예약 날짜를 선택할 수 없었던 버그 해결
: 각 달력에서 지난 달 날짜와 다음 달 날짜는 제거. (클릭 시 9월 31일이라고 뜨는 대참사 발생하여 제거하는 것이 낫겠다고 판단)
: 마감 날짜 x월 00일로 뜨는 문제 해결
: 시작 날짜가 오늘 날짜보다 작으면 선택이 안되는 버그 해결
- 예약 시작 날짜/예약 마감 날짜 사이의 모든 날짜들에 민트색 배경을 지정하는 UI 작업 (styled-components 사용)

### 화면/테스트 결과
예약 시작 날짜의 연도와 예약 마감 날짜의 연도가 같은 case까지 구현
![화면-기록-2023-07-08-오후-9 56 46 (1)](https://github.com/codestates-seb/seb44_main_028/assets/117507731/c4d7c008-a92a-4fa9-816f-57c99291d54a)



### 배운점
- 케이스 별로 나눠서 수도 코딩을 했던 작업이 크게 도움이 되었다.
1) 예약 시작 날짜와 예약 마감 날짜의 연도가 같은 경우

1-1) 예약 시작 날짜와 예약 마감 날짜의 월이 같은 경우
예약 시작 날짜의 date과 같거나 크고 예약 마감 날짜의 date보다 작거나 같으면 배경 지정
1-2) 예약 시작 날짜와 예약 마감 날짜의 월이 다른 경우
예약 시작 날짜가 포함된 월에서는 예약 시작 날짜의 date보다 큰 날짜만 배경 지정, 예약 마감 날짜만 포함된 월에서는 예약 마감 날짜의 date보다 작은 날짜만 배경 지정.
[예약 마감월 - 예약 시작월 > 1일 경우] 예약 시작일보다 월이 크고 예약 마감일보다 월이 작으면 모든 날짜에 배경 지정

2) 예약 시작 날짜보다 예약 마감 날짜의 연도가 더 큰 경우

2-1) [예약 마감 연도 - 예약 시작 연도 === 1일 경우]
예약 시작월에서 예약 시작일보다 크거나 같으면 배경 지정, 예약 시작월보다 크면 모든 날짜에 배경 지정
예약 마감월에서 예약 시작일보다 작거나 같으면 배경 지정, 예약 마감월보다 작으면 모든 날짜에 배경 지정
2-2) [예약 마감 연도 - 예약 시작 연도 > 1일 경우]
예약 시작 연도보다 연도가 크고, 예약 마감 날짜보다 연도가 작은 모든 날짜에 배경 지정하는 로직 추가

- 달력 버그를 잡으면서 redux store의 action 조건 부분 중간 리팩토링을 했더니 버그 잡는 시간이 단축되었다. (코드 가독성 향상)
- 로그인 구현 완성되면 중첩 라우터 구현할 예정