### PR TITLE
[FE] 헤더 UI refactor

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,18 +6,21 @@ import Header from './pages/Header/views/Header';
 import Footer from './pages/Footer/views/Footer';
 import Container from '@mui/material/Container';
 import { store } from './common/store/RootStore';
+import { BrowserRouter } from 'react-router-dom';
 
 function App() {
   const queryClient = new QueryClient();
   return (
     <QueryClientProvider client={queryClient}>
-      <Header />
-      <Container maxWidth="lg">
-        <Provider store={store}>
-          <Router />
-        </Provider>
-      </Container>
-      <Footer prop1={'플레이 팩'} />
+      <BrowserRouter>
+        <Header />
+        <Container maxWidth="lg">
+          <Provider store={store}>
+            <Router />
+          </Provider>
+        </Container>
+        <Footer prop1={'플레이 팩'} />
+      </BrowserRouter>
     </QueryClientProvider>
   );
 }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,7 +14,7 @@ function App() {
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
         <Header />
-        <Container maxWidth="lg">
+        <Container maxWidth="lg" style={{ paddingTop: '4.5rem' }}>
           <Provider store={store}>
             <Router />
           </Provider>

--- a/client/src/Router.tsx
+++ b/client/src/Router.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom';
 import MainPage from './pages/Main/views/MainPage';
 import MyPage from './pages/MyPage/views/MyPage';
 import LoginPage from './pages/Login/views/LoginPage';
@@ -11,19 +11,17 @@ import BookingPage from './pages/Booking/views/BookingPage';
 
 function Router() {
   return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<MainPage />} />
-        <Route path="/login" element={<LoginPage />} />
-        <Route path="/itemlist/:categoryId" element={<ItemListPage />} />
-        <Route path="/booking/:itemId" element={<BookingPage />} />
-        <Route path="/mypage" element={<MyPage />} />
-        <Route path="/detail/:itemId" element={<DetailPage />} />
-        <Route path="/create" element={<CreatePage />} />
-        <Route path="/update/:itemId" element={<UpdatePage />} />
-        <Route path="/chatting" element={<ChattingPage />} />
-      </Routes>
-    </BrowserRouter>
+    <Routes>
+      <Route path="/" element={<MainPage />} />
+      <Route path="/login" element={<LoginPage />} />
+      <Route path="/itemlist/:categoryId" element={<ItemListPage />} />
+      <Route path="/booking/:itemId" element={<BookingPage />} />
+      <Route path="/mypage" element={<MyPage />} />
+      <Route path="/detail/:itemId" element={<DetailPage />} />
+      <Route path="/create" element={<CreatePage />} />
+      <Route path="/update/:itemId" element={<UpdatePage />} />
+      <Route path="/chatting" element={<ChattingPage />} />
+    </Routes>
   );
 }
 export default Router;

--- a/client/src/common/utils/enum/colorPalette.ts
+++ b/client/src/common/utils/enum/colorPalette.ts
@@ -9,6 +9,7 @@ export enum colorPalette {
   grayTextColor = '#777',
   lightGrayTextColor = '#BABABA',
   borderColor = '#CBCBCB',
+  headerSearchColor = '#f1f1f1',
   tagColor = '#74D4E4',
   modalIconColor = '#D0E2Ef',
   modalCancelButtonColor = '#CDDBF0',

--- a/client/src/common/utils/enum/fontSize.ts
+++ b/client/src/common/utils/enum/fontSize.ts
@@ -2,4 +2,6 @@ export enum fontSize {
   basic = '16px',
   cardTitle = '20px',
   NoDataText = '24px',
+  headerNavText = '24px',
+  headerIconSize = '18px',
 }

--- a/client/src/pages/Header/constants.ts
+++ b/client/src/pages/Header/constants.ts
@@ -1,2 +1,11 @@
 export const LogoText = '플레이 팩';
-export const NavMenu: string[] = ['마이페이지', '글 작성하기'];
+export const NavMenuList = [
+  {
+    href: '/mypage',
+    title: '마이페이지',
+  },
+  {
+    href: '/create',
+    title: '글 작성하기',
+  },
+];

--- a/client/src/pages/Header/constants.ts
+++ b/client/src/pages/Header/constants.ts
@@ -1,5 +1,6 @@
+import { NavMenuListData } from './type';
 export const LogoText = '플레이 팩';
-export const NavMenuList = [
+export const NavMenuList: NavMenuListData[] = [
   {
     href: '/mypage',
     title: '마이페이지',

--- a/client/src/pages/Header/style.ts
+++ b/client/src/pages/Header/style.ts
@@ -1,5 +1,7 @@
 import styled, { css, keyframes } from 'styled-components';
 import { colorPalette } from '../../common/utils/enum/colorPalette';
+import { fontSize } from '../../common/utils/enum/fontSize';
+import { border } from '../../common/utils/enum/border';
 
 export const HeaderContainer = styled.header`
   display: flex;
@@ -7,7 +9,7 @@ export const HeaderContainer = styled.header`
   height: 4.5rem;
   padding: 1.375rem 2.625rem;
   font-size: 16px;
-  border-bottom: 1px solid #cbcbcb;
+  border-bottom: ${border.basic};
   background-color: ${colorPalette.whiteColor};
   position: fixed;
   top: 0;
@@ -19,15 +21,15 @@ export const HeaderContainer = styled.header`
   }
   & svg:hover,
   li:hover {
-    color: #12d3cf;
+    color: ${colorPalette.accentColor};
     transition: color 0.2s ease-in-out;
   }
 `;
 export const LogoWrapper = styled.div`
   width: 10%;
-  font-size: 24px;
+  font-size: ${fontSize.headerNavText};
   font-weight: 700;
-  color: #3aa6b9;
+  color: ${colorPalette.deepMintColor};
 `;
 export const NavWrapper = styled.div`
   flex: 1;
@@ -46,7 +48,7 @@ export const NavIconWrapper = styled.div`
   align-items: center;
 `;
 export const NavSendIconWrapper = styled.div`
-  font-size: 18px;
+  font-size: ${fontSize.headerIconSize};
   margin-right: 10.125rem;
   margin-left: 2rem;
 `;
@@ -77,13 +79,14 @@ export const NavSearchForm = styled.form<{ isClick: boolean }>`
     width: 20px;
     height: 20px;
     z-index: 1;
-    color: ${(props) => (props.isClick ? '#ffff' : 'inherit')};
+    color: ${(props) =>
+      props.isClick ? `${colorPalette.whiteColor}` : 'inherit'};
   }
   & > input {
     height: 26px;
     border-radius: 20px;
     transform: translateX(28px);
-    background-color: #f1f1f1;
+    background-color: ${colorPalette.headerSearchColor};
     border: none;
     padding: 0.5rem 1rem;
     padding-right: 2.5rem;
@@ -119,7 +122,7 @@ export const LogoutInfo = styled.div<{ isHovered: boolean }>`
   position: absolute;
   width: 70px;
   height: 35px;
-  background-color: #fff;
+  background-color: ${colorPalette.whiteColor};
   top: 30px;
   right: -15px;
   border-radius: 5px;
@@ -127,7 +130,7 @@ export const LogoutInfo = styled.div<{ isHovered: boolean }>`
   &::before {
     content: '';
     border-right: 13px solid transparent;
-    border-bottom: 13px solid #fff;
+    border-bottom: 13px solid ${colorPalette.whiteColor};
     position: absolute;
     top: -9px;
     right: 17px;

--- a/client/src/pages/Header/style.ts
+++ b/client/src/pages/Header/style.ts
@@ -1,4 +1,5 @@
 import styled, { css, keyframes } from 'styled-components';
+import { colorPalette } from '../../common/utils/enum/colorPalette';
 
 export const HeaderContainer = styled.header`
   display: flex;
@@ -7,6 +8,7 @@ export const HeaderContainer = styled.header`
   padding: 1.375rem 2.625rem;
   font-size: 16px;
   border-bottom: 1px solid #cbcbcb;
+  background-color: ${colorPalette.whiteColor};
   position: fixed;
   top: 0;
   width: 100%;

--- a/client/src/pages/Header/style.ts
+++ b/client/src/pages/Header/style.ts
@@ -7,6 +7,10 @@ export const HeaderContainer = styled.header`
   padding: 1.375rem 2.625rem;
   font-size: 16px;
   border-bottom: 1px solid #cbcbcb;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 5;
   & svg,
   li {
     cursor: pointer;

--- a/client/src/pages/Header/style.ts
+++ b/client/src/pages/Header/style.ts
@@ -77,7 +77,7 @@ export const NavSearchForm = styled.form<{ isClick: boolean }>`
     height: 26px;
     border-radius: 20px;
     transform: translateX(28px);
-    background-color: #d6d6d6;
+    background-color: #f1f1f1;
     border: none;
     padding: 0.5rem 1rem;
     padding-right: 2.5rem;
@@ -89,6 +89,9 @@ export const NavSearchForm = styled.form<{ isClick: boolean }>`
         : css`
             ${slideOutToRight} 0.3s ease-in-out forwards;
           `};
+  }
+  & > input:focus {
+    outline: none;
   }
 `;
 

--- a/client/src/pages/Header/type.ts
+++ b/client/src/pages/Header/type.ts
@@ -1,0 +1,4 @@
+export type NavMenuListData = {
+  href: string;
+  title: string;
+};

--- a/client/src/pages/Header/views/Header.tsx
+++ b/client/src/pages/Header/views/Header.tsx
@@ -22,43 +22,41 @@ function Header() {
   };
 
   return (
-    <Router>
-      <HeaderContainer>
-        <LogoWrapper>
-          <Link to="/">{LogoText}</Link>
-        </LogoWrapper>
-        <NavWrapper>
-          <ol>
-            <NavList>
-              <Link to="/mypage">{NavMenu[0]}</Link>
-            </NavList>
-            <NavList>
-              <Link to="/create">{NavMenu[1]}</Link>
-            </NavList>
-          </ol>
-          <NavIconWrapper>
-            <NavSearchForm isClick={isClick}>
-              <input type="text" />
-              <MdSearch onClick={handleClick} />
-            </NavSearchForm>
-            <NavSendIconWrapper>
-              <Link to="/chatting">
-                <MdSend />
-              </Link>
-            </NavSendIconWrapper>
-          </NavIconWrapper>
-        </NavWrapper>
-        <ActionWrapper>
-          <Link to="/login">
-            <MdLogout
-              onMouseEnter={() => setIsLogoutHovered(true)}
-              onMouseLeave={() => setIsLogoutHovered(false)}
-            />
-          </Link>
-          <LogoutInfo isHovered={isLogoutHovered}>logout</LogoutInfo>
-        </ActionWrapper>
-      </HeaderContainer>
-    </Router>
+    <HeaderContainer>
+      <LogoWrapper>
+        <Link to="/">{LogoText}</Link>
+      </LogoWrapper>
+      <NavWrapper>
+        <ol>
+          <NavList>
+            <Link to="/mypage">{NavMenu[0]}</Link>
+          </NavList>
+          <NavList>
+            <Link to="/create">{NavMenu[1]}</Link>
+          </NavList>
+        </ol>
+        <NavIconWrapper>
+          <NavSearchForm isClick={isClick}>
+            <input type="text" />
+            <MdSearch onClick={handleClick} />
+          </NavSearchForm>
+          <NavSendIconWrapper>
+            <Link to="/chatting">
+              <MdSend />
+            </Link>
+          </NavSendIconWrapper>
+        </NavIconWrapper>
+      </NavWrapper>
+      <ActionWrapper>
+        <Link to="/login">
+          <MdLogout
+            onMouseEnter={() => setIsLogoutHovered(true)}
+            onMouseLeave={() => setIsLogoutHovered(false)}
+          />
+        </Link>
+        <LogoutInfo isHovered={isLogoutHovered}>logout</LogoutInfo>
+      </ActionWrapper>
+    </HeaderContainer>
   );
 }
 export default Header;

--- a/client/src/pages/Header/views/Header.tsx
+++ b/client/src/pages/Header/views/Header.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { BrowserRouter as Router, Link } from 'react-router-dom';
 import { MdSearch, MdSend, MdLogout } from 'react-icons/md';
-import { LogoText, NavMenu } from '../constants';
+import { LogoText, NavMenuList } from '../constants';
 import {
   HeaderContainer,
   LogoWrapper,
@@ -28,12 +28,11 @@ function Header() {
       </LogoWrapper>
       <NavWrapper>
         <ol>
-          <NavList>
-            <Link to="/mypage">{NavMenu[0]}</Link>
-          </NavList>
-          <NavList>
-            <Link to="/create">{NavMenu[1]}</Link>
-          </NavList>
+          {NavMenuList.map((NavMenu, index) => (
+            <NavList key={index}>
+              <Link to={NavMenu.href}>{NavMenu.title}</Link>
+            </NavList>
+          ))}
         </ol>
         <NavIconWrapper>
           <NavSearchForm isClick={isClick}>

--- a/client/src/pages/Header/views/Header.tsx
+++ b/client/src/pages/Header/views/Header.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { BrowserRouter as Router, Link } from 'react-router-dom';
 import { MdSearch, MdSend, MdLogout } from 'react-icons/md';
 import { LogoText, NavMenu } from '../constants';


### PR DESCRIPTION
### 기능 요약
- input focus 시 outline 제거, input 배경 색 변경
- 헤더 `position: fixed`로 준 뒤 `width: 100%` 줘서 왼쪽으로 밀리는 이슈 해결
- `fixed`로 주니 본문이 헤더 위치로 올라오는 이슈 해결
- NavMenuList 하드코딩한 코드 수정
- color, fontsize 변수로 지정
- z-index 값 부여

### 화면/테스트 결과
<img width="1510" alt="스크린샷 2023-07-10 오전 2 29 44" src="https://github.com/codestates-seb/seb44_main_028/assets/72354092/121eacce-5de7-4e67-93d7-4e3a0d4cd466">

### 배운점
- header에 fixed를 주면 헤더가 뷰포트 상단에 고정되고 전체 너비를 차지하게 됩니다. 이로 인해 다른 콘텐츠가 헤더 아래로 밀려나가지 않고 헤더 위에 겹치는 현상이 발생합니다.
- 본문 컨텐츠에 `padding-top`을 헤더의 높이 만큼 주어 해당 이슈 해결할 수 있었습니다.