### PR TITLE
[FE] 1차 Modal Refactor

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -31,7 +31,6 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <div id="modal-root"></div>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/client/src/common/components/Modal/ModalButton.tsx
+++ b/client/src/common/components/Modal/ModalButton.tsx
@@ -1,0 +1,8 @@
+import { ModalButtonProps } from '../../type';
+
+const ModalButton = ({ children }: ModalButtonProps) => {
+  //나중에 merge 이후 버튼 컴포넌트 사용
+  return <button>{children}</button>;
+};
+
+export default ModalButton;

--- a/client/src/common/components/Modal/ModalButton.tsx
+++ b/client/src/common/components/Modal/ModalButton.tsx
@@ -1,8 +1,8 @@
 import { ModalButtonProps } from '../../type';
 
-const ModalButton = ({ children }: ModalButtonProps) => {
+const ModalButton = ({ children, onClick }: ModalButtonProps) => {
   //나중에 merge 이후 버튼 컴포넌트 사용
-  return <button>{children}</button>;
+  return <button onClick={onClick}>{children}</button>;
 };
 
 export default ModalButton;

--- a/client/src/common/components/Modal/ModalButtonProps.tsx
+++ b/client/src/common/components/Modal/ModalButtonProps.tsx
@@ -1,0 +1,7 @@
+import Button from '../Button';
+
+const ModalButtonProps = ({ children }) => {
+  return <Button>{children}</Button>;
+};
+
+export default ModalButtonProps;

--- a/client/src/common/components/Modal/ModalButtonProps.tsx
+++ b/client/src/common/components/Modal/ModalButtonProps.tsx
@@ -1,7 +1,0 @@
-import Button from '../Button';
-
-const ModalButtonProps = ({ children }) => {
-  return <Button>{children}</Button>;
-};
-
-export default ModalButtonProps;

--- a/client/src/common/components/Modal/ModalMain.tsx
+++ b/client/src/common/components/Modal/ModalMain.tsx
@@ -1,20 +1,38 @@
+import { useState, useRef } from 'react';
 import { createPortal } from 'react-dom';
+import { MdError } from 'react-icons/md';
 import ModalTitle from './ModalTitle';
 import ModalButton from './ModalButton';
 import { ModalMainProps } from '../../type';
+import { ModalOverlay, ModalWrapper } from '../../style/style';
 
 const ModalMain = ({ children, isOpen }: ModalMainProps) => {
+  const [isOverlayVisible, setIsOverlayVisible] = useState(true);
+  const modalRef = useRef<HTMLDivElement>(null);
+  const handleCloseModal = () => {
+    setIsOverlayVisible(false);
+  };
+  const handleModalContentClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+  };
   if (!isOpen) return null;
   return createPortal(
-    <div>
-      {ModalTitle && <ModalTitle />}
-      {ModalButton && <ModalButton />}
-    </div>,
+    <>
+      {isOverlayVisible && <ModalOverlay onClick={handleCloseModal} />}
+      {isOverlayVisible && (
+        <ModalWrapper ref={modalRef}>
+          <div onClick={handleModalContentClick}>
+            <MdError />
+            {children}
+          </div>
+        </ModalWrapper>
+      )}
+    </>,
     document.body,
   );
 };
 
 export default Object.assign(ModalMain, {
-  ModalTitle,
-  ModalButton,
+  Title: ModalTitle,
+  Button: ModalButton,
 });

--- a/client/src/common/components/Modal/ModalMain.tsx
+++ b/client/src/common/components/Modal/ModalMain.tsx
@@ -1,8 +1,9 @@
 import { createPortal } from 'react-dom';
 import ModalTitle from './ModalTitle';
 import ModalButton from './ModalButton';
+import { ModalMainProps } from '../../type';
 
-const ModalMain = ({ children, isOpen }) => {
+const ModalMain = ({ children, isOpen }: ModalMainProps) => {
   if (!isOpen) return null;
   return createPortal(
     <div>

--- a/client/src/common/components/Modal/ModalMain.tsx
+++ b/client/src/common/components/Modal/ModalMain.tsx
@@ -1,0 +1,16 @@
+import { createPortal } from 'react-dom';
+import ModalTitle from './ModalTitle';
+import ModalButton from './ModalButton';
+
+const ModalMain = ({ children, isOpen }) => {
+  if (!isOpen) return null;
+  return createPortal(
+    <div>
+      {ModalTitle && <ModalTitle />}
+      {ModalButton && <ModalButton />}
+    </div>,
+    document.body,
+  );
+};
+
+export default ModalMain;

--- a/client/src/common/components/Modal/ModalMain.tsx
+++ b/client/src/common/components/Modal/ModalMain.tsx
@@ -14,4 +14,7 @@ const ModalMain = ({ children, isOpen }: ModalMainProps) => {
   );
 };
 
-export default ModalMain;
+export default Object.assign(ModalMain, {
+  ModalTitle,
+  ModalButton,
+});

--- a/client/src/common/components/Modal/ModalTitle.tsx
+++ b/client/src/common/components/Modal/ModalTitle.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
+import { ModalTitleProps } from '../../type';
 
-const ModalTitle = ({ children }) => {
+const ModalTitle = ({ children }: ModalTitleProps) => {
   return <div>{children}</div>;
 };
 

--- a/client/src/common/components/Modal/ModalTitle.tsx
+++ b/client/src/common/components/Modal/ModalTitle.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const ModalTitle = ({ children }) => {
+  return <div>{children}</div>;
+};
+
+export default ModalTitle;

--- a/client/src/common/type.ts
+++ b/client/src/common/type.ts
@@ -1,3 +1,5 @@
+import { ReactNode } from 'react';
+
 export type CategoryButtonProps = {
   imageUrl: string;
   imageName: string;
@@ -23,4 +25,8 @@ export type CheckBoxProps = {
   categoryData: string;
   selectedCategories: string[];
   setSelectedCategories: React.Dispatch<React.SetStateAction<string[]>>;
+};
+export type ModalButtonProps = {
+  children?: ReactNode;
+  onClick?: (e: MouseEvent) => void;
 };

--- a/client/src/common/type.ts
+++ b/client/src/common/type.ts
@@ -33,3 +33,7 @@ export type ModalButtonProps = {
 export type ModalTitleProps = {
   children?: ReactNode;
 };
+export type ModalMainProps = {
+  children?: ReactNode;
+  isOpen?: boolean;
+};

--- a/client/src/common/type.ts
+++ b/client/src/common/type.ts
@@ -30,3 +30,6 @@ export type ModalButtonProps = {
   children?: ReactNode;
   onClick?: (e: MouseEvent) => void;
 };
+export type ModalTitleProps = {
+  children?: ReactNode;
+};

--- a/client/src/common/type.ts
+++ b/client/src/common/type.ts
@@ -28,7 +28,7 @@ export type CheckBoxProps = {
 };
 export type ModalButtonProps = {
   children?: ReactNode;
-  onClick?: (e: MouseEvent) => void;
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 };
 export type ModalTitleProps = {
   children?: ReactNode;

--- a/client/src/pages/Main/views/MainPage.tsx
+++ b/client/src/pages/Main/views/MainPage.tsx
@@ -1,10 +1,17 @@
-import React from 'react';
+import { useState } from 'react';
+import ModalMain from '../../../common/components/Modal/ModalMain';
 import ScrollToTop from '../../../common/components/ScrollToTop';
 
 function MainPage() {
+  const [isClick, setIsClick] = useState(false);
+  const handleModalTest = () => {
+    setIsClick(!isClick);
+  };
   return (
     <>
       <div>Main page</div>
+      <button onClick={handleModalTest}>버튼</button>
+      {isClick && <ModalMain isOpen={isClick} />}
       <ScrollToTop />
     </>
   );

--- a/client/src/pages/Main/views/MainPage.tsx
+++ b/client/src/pages/Main/views/MainPage.tsx
@@ -3,15 +3,23 @@ import ModalMain from '../../../common/components/Modal/ModalMain';
 import ScrollToTop from '../../../common/components/ScrollToTop';
 
 function MainPage() {
-  const [isClick, setIsClick] = useState(false);
-  const handleModalTest = () => {
-    setIsClick(!isClick);
-  };
+  // const [isClick, setIsClick] = useState(false);
+  // const handleModalTest = () => {
+  //   setIsClick(!isClick);
+  // };
   return (
     <>
       <div>Main page</div>
-      <button onClick={handleModalTest}>버튼</button>
-      {isClick && <ModalMain isOpen={isClick} />}
+      {/* <button onClick={handleModalTest}>버튼</button>
+      {isClick && (
+        <ModalMain isOpen={isClick}>
+          <ModalMain.Title>다이슨 예약하시겠습니까?</ModalMain.Title>
+          <ModalMain.Button onClick={() => setIsClick(false)}>
+            돌아가기
+          </ModalMain.Button>
+          <ModalMain.Button>예약하기</ModalMain.Button>
+        </ModalMain>
+      )} */}
       <ScrollToTop />
     </>
   );


### PR DESCRIPTION
### 기능 요약
- 합성컴포넌트를 이용하여 모달 공통 컴포넌트 구현 
- 아직 미완성 (기능, 스타일 추가해야 할 점이 있음)

### 화면/테스트 결과

### 배운점
- 서브컴포넌트와 메인 컴포넌트를 활용하여 공통 컴포넌트를 사용할 때 원하는 내용을 더욱 쉽게 추가할 수 있다.
```ts
export const Dialog = Object.assign(DialogMain, {
  Dimmed: DialogDimmed,
  Title: DialogTitle,
  Subtitle: DialogSubtitle,
  Description: DialogDescription,
  Comment: DialogComment,
  CheckButton: DialogCheckButton,
  CheckBox: DialogCheckBox,
  TextButton: DialogTextButton,
  Button: DialogButton,
  LabelButton: DialogLabelButton,
  Divider: DialogDivider,
});

// Usage
<Dialog>
    <Dialog.Title>제목</Dialog.Title>
</Dialog>
```
- 이렇게 컴포넌트들을 묶어서 export할 수 있다는 것을 처음 알았다!
- `Portal`을 사용할 때 굳이 html 파일에서 div 요소를 추가할 필요가 없다. => (`CreaetPortal`을 사용하면 된다)
- 아직 완벽하게 이해한 상태는 아니다. 더욱 공부할 필요가 있을 듯 하다.

- 합성컴포넌트를 사용하여 모달 컴포넌트를 만들면 우리가 기획한 모달 중 별점 주기 모달만 윗 부분이 달라서 금희님이 따로 모달을 만들었는데 이 부분이 해소 될 수 있을 듯 하다.