### PR TITLE
[FE] 카카오 로그인 구현

### DIFF
--- a/client/src/PrivateRoutes.tsx
+++ b/client/src/PrivateRoutes.tsx
@@ -1,0 +1,11 @@
+import { Navigate, Outlet } from 'react-router-dom';
+import { ACCESS_TOKEN } from './pages/Login/constants';
+
+function PrivateRoutes() {
+  // TODO: 로그인 여부를 store에서 가져오기
+  const isLoggedIn = localStorage.getItem(ACCESS_TOKEN);
+
+  // TODO: 로그인 여부에 따라서 라우팅 처리
+  return isLoggedIn ? <Outlet /> : <Navigate to="/login" />;
+}
+export default PrivateRoutes;

--- a/client/src/Router.tsx
+++ b/client/src/Router.tsx
@@ -2,6 +2,7 @@ import { Routes, Route } from 'react-router-dom';
 import MainPage from './pages/Main/views/MainPage';
 import MyPage from './pages/MyPage/views/MyPage';
 import LoginPage from './pages/Login/views/LoginPage';
+import RedirectPage from './pages/Login/views/RedirectPage';
 import ItemListPage from './pages/ItemList/views/ItemListPage';
 import DetailPage from './pages/Detail/views/DetailPage';
 import CreatePage from './pages/Create/views/CreatePage';
@@ -14,6 +15,7 @@ function Router() {
     <Routes>
       <Route path="/" element={<MainPage />} />
       <Route path="/login" element={<LoginPage />} />
+      <Route path="/auth/callback" element={<RedirectPage />} />
       <Route path="/itemlist/:categoryId" element={<ItemListPage />} />
       <Route path="/booking/:itemId" element={<BookingPage />} />
       <Route path="/mypage" element={<MyPage />} />

--- a/client/src/Router.tsx
+++ b/client/src/Router.tsx
@@ -9,6 +9,7 @@ import CreatePage from './pages/Create/views/CreatePage';
 import UpdatePage from './pages/Update/views/UpdatePage';
 import ChattingPage from './pages/Chatting/views/ChattingPage';
 import BookingPage from './pages/Booking/views/BookingPage';
+import PrivateRoutes from './PrivateRoutes';
 
 function Router() {
   return (
@@ -17,12 +18,14 @@ function Router() {
       <Route path="/login" element={<LoginPage />} />
       <Route path="/auth/callback" element={<RedirectPage />} />
       <Route path="/itemlist/:categoryId" element={<ItemListPage />} />
-      <Route path="/booking/:itemId" element={<BookingPage />} />
-      <Route path="/mypage" element={<MyPage />} />
+      <Route element={<PrivateRoutes />}>
+        <Route path="/booking/:itemId" element={<BookingPage />} />
+        <Route path="/mypage" element={<MyPage />} />
+        <Route path="/create" element={<CreatePage />} />
+        <Route path="/update/:itemId" element={<UpdatePage />} />
+        <Route path="/chatting" element={<ChattingPage />} />
+      </Route>
       <Route path="/detail/:itemId" element={<DetailPage />} />
-      <Route path="/create" element={<CreatePage />} />
-      <Route path="/update/:itemId" element={<UpdatePage />} />
-      <Route path="/chatting" element={<ChattingPage />} />
     </Routes>
   );
 }

--- a/client/src/pages/Booking/components/Calendars.tsx
+++ b/client/src/pages/Booking/components/Calendars.tsx
@@ -8,35 +8,18 @@ import {
   ButtonWrapper,
   CalendarWrapper,
 } from '../style';
+import MonthSwitchBtns from './MonthSwitchBtns';
 
 function Calendars() {
-  const dispatch = useDispatch();
   const current = useSelector((state: RootState) => state.calendar);
   const next =
     current.month === 12
       ? { ...current, year: current.year + 1, month: 1 }
       : { ...current, month: current.month + 1 };
 
-  const onClickBack = () => {
-    if (current.month > 1) {
-      dispatch(setDate({ ...current, month: current.month - 1 }));
-    } else {
-      dispatch(setDate({ ...current, year: current.year - 1, month: 12 }));
-    }
-  };
-  const onClickNext = () => {
-    if (current.month < 12) {
-      dispatch(setDate({ ...current, month: current.month + 1 }));
-    } else {
-      dispatch(setDate({ ...current, year: current.year + 1, month: 1 }));
-    }
-  };
   return (
     <CalendarContainer>
-      <ButtonWrapper>
-        <Btn onClick={onClickBack}>◀️</Btn>
-        <Btn onClick={onClickNext}>▶️</Btn>
-      </ButtonWrapper>
+      <MonthSwitchBtns />
       <CalendarWrapper>
         <Calendar calendar={current} />
         <Calendar calendar={next} />

--- a/client/src/pages/Booking/components/MonthSwitchBtns.tsx
+++ b/client/src/pages/Booking/components/MonthSwitchBtns.tsx
@@ -1,0 +1,33 @@
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from '../../../common/store/RootStore';
+import { setDate } from '../store/CalendarStore';
+import { Btn, ButtonWrapper } from '../style';
+
+function MonthSwitchBtns() {
+  const dispatch = useDispatch();
+  const current = useSelector((state: RootState) => state.calendar);
+
+  const onClickBack = () => {
+    if (current.month > 1) {
+      dispatch(setDate({ ...current, month: current.month - 1 }));
+    } else {
+      dispatch(setDate({ ...current, year: current.year - 1, month: 12 }));
+    }
+  };
+
+  const onClickNext = () => {
+    if (current.month < 12) {
+      dispatch(setDate({ ...current, month: current.month + 1 }));
+    } else {
+      dispatch(setDate({ ...current, year: current.year + 1, month: 1 }));
+    }
+  };
+
+  return (
+    <ButtonWrapper>
+      <Btn onClick={onClickBack}>◀️</Btn>
+      <Btn onClick={onClickNext}>▶️</Btn>
+    </ButtonWrapper>
+  );
+}
+export default MonthSwitchBtns;

--- a/client/src/pages/Booking/components/MonthSwitchBtns.tsx
+++ b/client/src/pages/Booking/components/MonthSwitchBtns.tsx
@@ -1,11 +1,15 @@
+import { useParams } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '../../../common/store/RootStore';
 import { setDate } from '../store/CalendarStore';
 import { Btn, ButtonWrapper } from '../style';
+import axios from 'axios';
 
 function MonthSwitchBtns() {
   const dispatch = useDispatch();
   const current = useSelector((state: RootState) => state.calendar);
+  const { itemId } = useParams<{ itemId: string }>();
+  console.log('현재 날짜', current);
 
   const onClickBack = () => {
     if (current.month > 1) {
@@ -13,6 +17,16 @@ function MonthSwitchBtns() {
     } else {
       dispatch(setDate({ ...current, year: current.year - 1, month: 12 }));
     }
+    // const response = axios.get(
+    //   `https://playpack.shop/api/reservations/products/api/reservations/products/${itemId}/moreCalendar?date=${current.year}-${current.month}-${current.date}`,
+    // );
+    // console.log(response);
+    // console.log('현재 날짜', current);
+    console.log(
+      '왼쪽 버튼 누를 때 요청할 지난 달',
+      current.month === 1 ? current.year - 1 : current.year,
+      current.month === 1 ? 12 : current.month - 1,
+    );
   };
 
   const onClickNext = () => {
@@ -21,6 +35,20 @@ function MonthSwitchBtns() {
     } else {
       dispatch(setDate({ ...current, year: current.year + 1, month: 1 }));
     }
+
+    // const response = axios.get(
+    //   `https://playpack.shop/api/reservations/products/api/reservations/products/${itemId}/moreCalendar?date=2023-01-01`,
+    // );
+    // console.log(response);
+    console.log(
+      '오른쪽 버튼 누를 때 요청할 다음 달',
+      current.month === 11 || current.month === 12
+        ? current.year + 1
+        : current.year,
+      current.month === 11 || current.month === 12
+        ? current.month - 10
+        : current.month + 2,
+    );
   };
 
   return (

--- a/client/src/pages/Booking/components/ReservationBtn.tsx
+++ b/client/src/pages/Booking/components/ReservationBtn.tsx
@@ -13,7 +13,7 @@ const sendReservationData = async ({
 }: IReservationData) => {
   try {
     const response = await axios.post(
-      `https://playpack.shop/api/reservations/products/${productId}`,
+      `${process.env.REACT_APP_API_URL}/api/reservations/products/${productId}`,
       {
         startDate: startDate,
         endDate: endDate,

--- a/client/src/pages/Login/components/KakaoLogin.tsx
+++ b/client/src/pages/Login/components/KakaoLogin.tsx
@@ -166,100 +166,10 @@ import { KakaoLoginBtn } from '../style';
 // };
 
 function KakaoLogin() {
-  localStorage.clear();
-  const location = useLocation();
-  const { access_token } = useParams<{ access_token: string }>();
-
   // 1. 카카오 로그인 버튼 클릭 시 응답으로 반환 받은 redirect uri로 이동
   const handleKakaoLogin = () => {
     window.location.href = `${process.env.REACT_APP_API_URL}/oauth2/authorization/kakao`;
   };
-
-  // 3. redirect uri에서 인가 코드를 추출하여 state에 저장
-  const getAccessToken = () => {
-    console.log('location', location);
-    const access_token: string | null = new URLSearchParams(
-      location.search,
-    ).get('access_token');
-    console.log(access_token);
-    if (access_token) {
-      localStorage.setItem('playback-token', access_token);
-    } else {
-      console.log('no authorizationCode');
-    }
-  };
-
-  const getMember = async () => {
-    const access_token = localStorage.getItem('playback-token');
-    console.log('test', access_token);
-    if (access_token) {
-      try {
-        const { data } = await axios.get(
-          `${process.env.REACT_APP_API_URL}/api/members`,
-          {
-            headers: { Authorization: 'Bearer ' + access_token },
-          },
-        );
-        console.log('data:', data);
-        return data;
-      } catch (error) {
-        console.log(error);
-      }
-    }
-  };
-
-  // 2. redirect uri로 이동 후 인가 코드 추출하는 함수 호출
-  useEffect(() => {
-    if (window.location.pathname === '/auth/callback') {
-      console.log('/auth/callback');
-      getAccessToken();
-    }
-    getMember();
-  }, [window.location.pathname]);
-
-  // // 4. 인가 코드를 back으로 보냄
-  // const encryptedAuthorizationCode: string | null =
-  //   localStorage.getItem('authorizationCode');
-  // let authorizationCode: string | null = null;
-
-  // if (encryptedAuthorizationCode) {
-  //   authorizationCode = decrypt(encryptedAuthorizationCode);
-  // }
-
-  // console.log(
-  //   '3. localStorage에서 가져온 authorizationCode',
-  //   authorizationCode,
-  // );
-
-  // const {
-  //   data: userData,
-  //   isError,
-  //   error,
-  // } = useQuery(
-  //   ['user', authorizationCode],
-  //   () => fetchUserData(authorizationCode),
-  //   {
-  //     enabled: !!authorizationCode,
-  //   },
-  // );
-  // console.log('4. 서버에서 받아온 유저 정보', userData);
-
-  // if (isError) {
-  //   console.log(error);
-  // }
-
-  // // 5. 유저 정보를 store에 저장
-  // useEffect(() => {
-  //   if (userData) {
-  //     dispatch(
-  //       createUserInfo({
-  //         displayName: userData.displayName,
-  //         latitude: userData.latitude,
-  //         longitude: userData.longitude,
-  //       }),
-  //     );
-  //   }
-  // }, [userData]);
 
   return <KakaoLoginBtn onClick={handleKakaoLogin} />;
 }

--- a/client/src/pages/Login/components/KakaoLogin.tsx
+++ b/client/src/pages/Login/components/KakaoLogin.tsx
@@ -150,7 +150,7 @@
 
 import { useEffect } from 'react';
 import { useQuery } from 'react-query';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 import axios from 'axios';
 import { KakaoLoginBtn } from '../style';
 import { useDispatch } from 'react-redux';
@@ -171,7 +171,9 @@ import useDecryptToken from '../../../common/utils/customHooks/useDecryptToken';
 // };
 
 function KakaoLogin() {
+  localStorage.clear();
   const location = useLocation();
+  const { access_token } = useParams<{ access_token: string }>();
 
   // 1. 카카오 로그인 버튼 클릭 시 응답으로 반환 받은 redirect uri로 이동
   const handleKakaoLogin = () => {
@@ -180,6 +182,7 @@ function KakaoLogin() {
 
   // 3. redirect uri에서 인가 코드를 추출하여 state에 저장
   const getAccessToken = () => {
+    console.log('location', location);
     const access_token: string | null = new URLSearchParams(
       location.search,
     ).get('access_token');
@@ -212,9 +215,12 @@ function KakaoLogin() {
 
   // 2. redirect uri로 이동 후 인가 코드 추출하는 함수 호출
   useEffect(() => {
-    getAccessToken();
+    if (window.location.pathname === '/auth/callback') {
+      console.log('/auth/callback');
+      getAccessToken();
+    }
     getMember();
-  }, [location]);
+  }, [window.location.pathname]);
 
   // // 4. 인가 코드를 back으로 보냄
   // const encryptedAuthorizationCode: string | null =

--- a/client/src/pages/Login/components/KakaoLogin.tsx
+++ b/client/src/pages/Login/components/KakaoLogin.tsx
@@ -149,14 +149,9 @@
  */
 
 import { useEffect } from 'react';
-import { useQuery } from 'react-query';
 import { useLocation, useParams } from 'react-router-dom';
 import axios from 'axios';
 import { KakaoLoginBtn } from '../style';
-import { useDispatch } from 'react-redux';
-import { createUserInfo } from '../../../common/store/UserInfoStore';
-import useEncryptToken from '../../../common/utils/customHooks/useEncryptToken';
-import useDecryptToken from '../../../common/utils/customHooks/useDecryptToken';
 
 // const fetchUserData = async (code: string | null) => {
 //   if (!code) return;

--- a/client/src/pages/Login/components/KakaoLogin.tsx
+++ b/client/src/pages/Login/components/KakaoLogin.tsx
@@ -175,7 +175,7 @@ function KakaoLogin() {
 
   // 1. 카카오 로그인 버튼 클릭 시 응답으로 반환 받은 redirect uri로 이동
   const handleKakaoLogin = () => {
-    window.location.href = 'https://playpack.shop/oauth2/authorization/kakao';
+    window.location.href = `${process.env.REACT_APP_API_URL}/oauth2/authorization/kakao`;
   };
 
   // 3. redirect uri에서 인가 코드를 추출하여 state에 저장
@@ -196,9 +196,12 @@ function KakaoLogin() {
     console.log('test', access_token);
     if (access_token) {
       try {
-        const { data } = await axios.get(`https://playpack.shop/api/members`, {
-          headers: { Authorization: 'Bearer ' + access_token },
-        });
+        const { data } = await axios.get(
+          `${process.env.REACT_APP_API_URL}/api/members`,
+          {
+            headers: { Authorization: 'Bearer ' + access_token },
+          },
+        );
         console.log('data:', data);
         return data;
       } catch (error) {

--- a/client/src/pages/Login/components/KakaoLogin.tsx
+++ b/client/src/pages/Login/components/KakaoLogin.tsx
@@ -148,10 +148,9 @@
  * 여기서부터 임시 코드
  */
 
-import { useEffect } from 'react';
-import { useLocation, useParams } from 'react-router-dom';
-import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
 import { KakaoLoginBtn } from '../style';
+import { ACCESS_TOKEN } from '../constants';
 
 // const fetchUserData = async (code: string | null) => {
 //   if (!code) return;
@@ -166,11 +165,24 @@ import { KakaoLoginBtn } from '../style';
 // };
 
 function KakaoLogin() {
+  const navigate = useNavigate();
   // 1. 카카오 로그인 버튼 클릭 시 응답으로 반환 받은 redirect uri로 이동
   const handleKakaoLogin = () => {
     window.location.href = `${process.env.REACT_APP_API_URL}/oauth2/authorization/kakao`;
   };
 
-  return <KakaoLoginBtn onClick={handleKakaoLogin} />;
+  return (
+    <>
+      <KakaoLoginBtn onClick={handleKakaoLogin} />
+      <button
+        onClick={() => {
+          localStorage.removeItem(ACCESS_TOKEN);
+          navigate('/');
+        }}
+      >
+        log out
+      </button>
+    </>
+  );
 }
 export default KakaoLogin;

--- a/client/src/pages/Login/constants.ts
+++ b/client/src/pages/Login/constants.ts
@@ -1,0 +1,1 @@
+export const ACCESS_TOKEN = 'access_token';

--- a/client/src/pages/Login/views/RedirectPage.tsx
+++ b/client/src/pages/Login/views/RedirectPage.tsx
@@ -1,11 +1,11 @@
 import { useEffect } from 'react';
-import { useQuery } from 'react-query';
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
-import { KakaoLoginBtn } from '../style';
+import { ACCESS_TOKEN } from '../constants';
 
 function RedirectPage() {
   const navigate = useNavigate();
+
   const getAccessToken = () => {
     console.log('location', location);
     const access_token: string | null = new URLSearchParams(
@@ -13,7 +13,7 @@ function RedirectPage() {
     ).get('access_token');
     console.log(access_token);
     if (access_token) {
-      localStorage.setItem('playback-token', access_token);
+      localStorage.setItem(ACCESS_TOKEN, access_token);
     } else {
       console.log('no authorizationCode');
     }
@@ -21,7 +21,7 @@ function RedirectPage() {
   };
 
   const getMember = async () => {
-    const access_token = localStorage.getItem('playback-token');
+    const access_token = localStorage.getItem(ACCESS_TOKEN);
     console.log('test', access_token);
     if (access_token) {
       try {
@@ -43,6 +43,49 @@ function RedirectPage() {
     getAccessToken();
     getMember();
   }, [window.location.pathname]);
+  // // 4. 인가 코드를 back으로 보냄
+  // const encryptedAuthorizationCode: string | null =
+  //   localStorage.getItem('authorizationCode');
+  // let authorizationCode: string | null = null;
+
+  // if (encryptedAuthorizationCode) {
+  //   authorizationCode = decrypt(encryptedAuthorizationCode);
+  // }
+
+  // console.log(
+  //   '3. localStorage에서 가져온 authorizationCode',
+  //   authorizationCode,
+  // );
+
+  // const {
+  //   data: userData,
+  //   isError,
+  //   error,
+  // } = useQuery(
+  //   ['user', authorizationCode],
+  //   () => fetchUserData(authorizationCode),
+  //   {
+  //     enabled: !!authorizationCode,
+  //   },
+  // );
+  // console.log('4. 서버에서 받아온 유저 정보', userData);
+
+  // if (isError) {
+  //   console.log(error);
+  // }
+
+  // // 5. 유저 정보를 store에 저장
+  // useEffect(() => {
+  //   if (userData) {
+  //     dispatch(
+  //       createUserInfo({
+  //         displayName: userData.displayName,
+  //         latitude: userData.latitude,
+  //         longitude: userData.longitude,
+  //       }),
+  //     );
+  //   }
+  // }, [userData]);
   return null;
 }
 export default RedirectPage;

--- a/client/src/pages/Login/views/RedirectPage.tsx
+++ b/client/src/pages/Login/views/RedirectPage.tsx
@@ -1,0 +1,48 @@
+import { useEffect } from 'react';
+import { useQuery } from 'react-query';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import axios from 'axios';
+import { KakaoLoginBtn } from '../style';
+
+function RedirectPage() {
+  const navigate = useNavigate();
+  const getAccessToken = () => {
+    console.log('location', location);
+    const access_token: string | null = new URLSearchParams(
+      location.search,
+    ).get('access_token');
+    console.log(access_token);
+    if (access_token) {
+      localStorage.setItem('playback-token', access_token);
+    } else {
+      console.log('no authorizationCode');
+    }
+    navigate('/');
+  };
+
+  const getMember = async () => {
+    const access_token = localStorage.getItem('playback-token');
+    console.log('test', access_token);
+    if (access_token) {
+      try {
+        const { data } = await axios.get(
+          `${process.env.REACT_APP_API_URL}/api/members`,
+          {
+            headers: { Authorization: 'Bearer ' + access_token },
+          },
+        );
+        console.log('data:', data);
+
+        return data;
+      } catch (error) {
+        console.log(error);
+      }
+    }
+  };
+  useEffect(() => {
+    getAccessToken();
+    getMember();
+  }, [window.location.pathname]);
+  return null;
+}
+export default RedirectPage;

--- a/client/src/pages/MyPage/constants.ts
+++ b/client/src/pages/MyPage/constants.ts
@@ -3,7 +3,7 @@ export const TAP = ['빌려준내역', '빌린내역', '관심 목록'];
 
 export const ITEMCARD_DATA: ItemCardProps[] = [
   {
-    id: 1,
+    id: '1',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,
@@ -18,7 +18,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
-    id: 2,
+    id: '2',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,
@@ -33,7 +33,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
-    id: 3,
+    id: '3',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,
@@ -48,7 +48,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
-    id: 4,
+    id: '4',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,
@@ -63,7 +63,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
-    id: 5,
+    id: '5',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,
@@ -78,7 +78,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
-    id: 6,
+    id: '6',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,
@@ -93,7 +93,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
-    id: 7,
+    id: '7',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,
@@ -108,7 +108,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
-    id: 8,
+    id: '8',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,
@@ -123,7 +123,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
-    id: 9,
+    id: '9',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,
@@ -138,7 +138,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
-    id: 10,
+    id: '10',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,
@@ -153,7 +153,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
-    id: 11,
+    id: '11',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,
@@ -168,7 +168,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
-    id: 12,
+    id: '12',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,


### PR DESCRIPTION
### 기능 요약
[카카오 로그인]
- 리디렉트 페이지 생성하여 access token 추출 후 local storage에 저장하는 로직 추가
: 추후 React-Query로 캐싱하는 로직으로 변경 예정
- 로그아웃 임시 버튼 생성
: 헤더 로그아웃 드롭다운 클릭 가능해지면 Header 컴포넌트로 코드 옮길 예정
- 중첩 라우터 구현
: 마이페이지, 글 작성 페이지 등 권한이 있는 유저만 접근 가능한 페이지를 Private Routes 내부로 이동
: "로그인이 필요합니다" 모달 추가 예정

### 화면/테스트 결과
![화면-기록-2023-07-12-오전-8 39 13](https://github.com/codestates-seb/seb44_main_028/assets/117507731/29221336-de2c-4c4f-88bc-aa1c103498ae)

### 배운점
- Redirect 페이지에서 access token을 추출하여 저장하고 main page로 리디렉트하는 방법이 있다는 걸 배웠다.