### PR TITLE
[FE] 2차 찜하기 구현

### DIFF
--- a/client/src/common/components/ItemCard/ItemCard.tsx
+++ b/client/src/common/components/ItemCard/ItemCard.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react';
-import { useMutation, useQuery } from 'react-query';
+import { useState } from 'react';
+import { useMutation } from 'react-query';
 import axios from 'axios';
 import { BsFillHeartFill } from 'react-icons/bs';
 import { MdLocationOn } from 'react-icons/md';
@@ -19,43 +19,40 @@ const ItemCard = ({ itemCardData }: { itemCardData: ItemCardProps }) => {
   const [isHeartClicked, setIsHeartClicked] = useState(false);
   const [interestId, setInterestId] = useState('');
 
-  const fetchInterestId = async () => {
-    const response = await axios.get(
-      `${process.env.REACT_APP_API_URL}/members/interests`,
-    );
-    return response.data?.interestId;
-  };
-  const { data: interestIdData } = useQuery('interestId', fetchInterestId);
-
-  useEffect(() => {
-    if (interestIdData) {
-      setInterestId(interestIdData);
-      setIsHeartClicked(true);
-    } else {
-      setInterestId('');
-      setIsHeartClicked(false);
-    }
-  }, [interestIdData]);
-
   const addInterestMutation = useMutation((productId: string) =>
-    axios.post(`${process.env.REACT_APP_API_URL}/interests`, {
-      //memberId: '1', // 멤버 id는 임시로 1로 설정
-      productId: productId,
-    }),
+    axios
+      .post(`${process.env.REACT_APP_API_URL}/api/members/interests`, {
+        memberId: '1',
+        productId: productId,
+      })
+      .then((res) => {
+        const { data } = res;
+        setInterestId(data.interestId);
+      }),
   );
 
-  const removeInterestMutation = useMutation((interestId: string) =>
-    axios.delete(
-      `${process.env.REACT_APP_API_URL}/interests?interestId=${interestId}`,
-    ),
+  const removeInterestMutation = useMutation(
+    (interestId: string) =>
+      axios.delete(`${process.env.REACT_APP_API_URL}/api/members/interests`, {
+        data: {
+          memberId: '1', // 멤버 id는 임시로 1로 설정
+          interestId: interestId,
+        },
+      }),
+    {
+      onError: (error) => {
+        // 에러 처리 로직 추가
+        console.error('removeInterestMutation error:', error);
+      },
+    },
   );
-
   const handleHeartClick = () => {
     if (isHeartClicked) {
       removeInterestMutation.mutate(interestId);
     } else {
       addInterestMutation.mutate(itemCardData.id);
     }
+    setIsHeartClicked(!isHeartClicked);
   };
 
   return (

--- a/client/src/common/components/ItemCard/ItemCardList.tsx
+++ b/client/src/common/components/ItemCard/ItemCardList.tsx
@@ -11,7 +11,7 @@ const ItemCardList = ({
       <p>{itemCardListTitle}</p>
       <ItemCardWrapper>
         {itemCardListContentData.map((itemcard) => (
-          <ItemCard itemCardData={itemcard} />
+          <ItemCard key={itemcard.id} itemCardData={itemcard} />
         ))}
       </ItemCardWrapper>
     </ItemCardListWrapper>

--- a/client/src/common/model/IInterest.tsx
+++ b/client/src/common/model/IInterest.tsx
@@ -1,0 +1,4 @@
+export interface IInterest {
+  isHeartClicked: boolean;
+  interest: string[];
+}

--- a/client/src/common/store/InterestStore.tsx
+++ b/client/src/common/store/InterestStore.tsx
@@ -1,5 +1,7 @@
 import { createSlice, configureStore, PayloadAction } from '@reduxjs/toolkit';
+import { useDispatch } from 'react-redux';
 import { IInterest } from '../model/IInterest';
+import { INTEREST_KEY } from '../../pages/Main/constants';
 const initialState: IInterest = {
   isHeartClicked: false,
   interest: [],
@@ -20,3 +22,18 @@ export const interestProducts = createSlice({
 });
 export const store = configureStore({ reducer: interestProducts.reducer });
 export const { addInterest, removeInterest } = interestProducts.actions;
+
+const initializeStateLocalStorageInterest = () => {
+  const interest = localStorage.getItem(INTEREST_KEY);
+  if (interest) {
+    store.dispatch(interestProducts.actions.addInterest(JSON.parse(interest)));
+  }
+};
+const saveStateToLocalStorageInterest = () => {
+  const newInterest = store.getState().interest;
+  localStorage.setItem(INTEREST_KEY, JSON.stringify(newInterest));
+};
+store.subscribe(saveStateToLocalStorageInterest);
+initializeStateLocalStorageInterest();
+export const useAppDispatch = () => useDispatch<typeof store.dispatch>();
+export default store;

--- a/client/src/common/store/InterestStore.tsx
+++ b/client/src/common/store/InterestStore.tsx
@@ -1,7 +1,6 @@
 import { createSlice, configureStore, PayloadAction } from '@reduxjs/toolkit';
 import { useDispatch } from 'react-redux';
 import { IInterest } from '../model/IInterest';
-import { INTEREST_KEY } from '../../pages/Main/constants';
 const initialState: IInterest = {
   isHeartClicked: false,
   interest: [],
@@ -23,17 +22,4 @@ export const interestProducts = createSlice({
 export const store = configureStore({ reducer: interestProducts.reducer });
 export const { addInterest, removeInterest } = interestProducts.actions;
 
-const initializeStateLocalStorageInterest = () => {
-  const interest = localStorage.getItem(INTEREST_KEY);
-  if (interest) {
-    store.dispatch(interestProducts.actions.addInterest(JSON.parse(interest)));
-  }
-};
-const saveStateToLocalStorageInterest = () => {
-  const newInterest = store.getState().interest;
-  localStorage.setItem(INTEREST_KEY, JSON.stringify(newInterest));
-};
-store.subscribe(saveStateToLocalStorageInterest);
-initializeStateLocalStorageInterest();
 export const useAppDispatch = () => useDispatch<typeof store.dispatch>();
-export default store;

--- a/client/src/common/store/InterestStore.tsx
+++ b/client/src/common/store/InterestStore.tsx
@@ -1,0 +1,22 @@
+import { createSlice, configureStore, PayloadAction } from '@reduxjs/toolkit';
+import { IInterest } from '../model/IInterest';
+const initialState: IInterest = {
+  isHeartClicked: false,
+  interest: [],
+};
+export const interestProducts = createSlice({
+  name: 'interestReducer',
+  initialState,
+  reducers: {
+    addInterest: (state, action: PayloadAction<string>) => {
+      state.isHeartClicked = true;
+      state.interest.push(action.payload);
+    },
+    removeInterest: (state, action: PayloadAction<string>) => {
+      state.isHeartClicked = false;
+      state.interest = state.interest.filter((id) => id !== action.payload);
+    },
+  },
+});
+export const store = configureStore({ reducer: interestProducts.reducer });
+export const { addInterest, removeInterest } = interestProducts.actions;

--- a/client/src/common/store/RootStore.tsx
+++ b/client/src/common/store/RootStore.tsx
@@ -2,11 +2,13 @@ import { combineReducers, configureStore } from '@reduxjs/toolkit';
 import { userInfo } from './UserInfoStore';
 import { calendar } from '../../pages/Booking/store/CalendarStore';
 import { reservation } from '../../pages/Booking/store/ReservationDateStore';
+import { interestProducts } from './InterestStore';
 
 const rootReducer = combineReducers({
   userInfo: userInfo.reducer,
   calendar: calendar.reducer,
   reservation: reservation.reducer,
+  interestProducts: interestProducts.reducer,
 });
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/client/src/pages/Main/constants.ts
+++ b/client/src/pages/Main/constants.ts
@@ -32,7 +32,7 @@ export const ITEMCARDLIST_TITLE: string[] = [
 ];
 export const ITEMCARD_DATA: ItemCardProps[] = [
   {
-    id: '1',
+    id: 'a4d59c7d-c8ec-47f2-b587-35d75905b808',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,
@@ -47,7 +47,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
-    id: '2',
+    id: '666fcda2-c743-4412-af15-a27ad16dd4eb',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,
@@ -62,7 +62,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
-    id: '3',
+    id: '506d3643-573f-4347-b51f-36cc7abcbccb',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,

--- a/client/src/pages/Main/constants.ts
+++ b/client/src/pages/Main/constants.ts
@@ -5,6 +5,7 @@ import SkiImage from '../../assets/image_slider/SkiImage.svg';
 import { ImageData } from './type';
 import { ItemCardProps } from '../../common/type';
 
+export const INTEREST_KEY = 'interest';
 export const IMAGE_SLIDER: ImageData[] = [
   {
     image: MainImage,
@@ -32,7 +33,7 @@ export const ITEMCARDLIST_TITLE: string[] = [
 ];
 export const ITEMCARD_DATA: ItemCardProps[] = [
   {
-    id: 'a4d59c7d-c8ec-47f2-b587-35d75905b808',
+    id: '86911664-5691-4fb3-b441-04e1eca38fb7',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,
@@ -47,7 +48,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
-    id: '666fcda2-c743-4412-af15-a27ad16dd4eb',
+    id: '97c61b71-f91f-47f8-8737-7e4e15cdb36f',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,


### PR DESCRIPTION
### 기능 요약
- 찜 하기, 찜 해제 서버 통신 구현
- `RTK, localStorage` 사용 하여 새로고침 해도 찜한 내역 유지 하도록 구현

### 화면/테스트 결과
![Jul-12-2023 23-07-16](https://github.com/codestates-seb/seb44_main_028/assets/72354092/7377821a-9d5f-442a-9361-08a7e903284e)

### 배운점
- `RTK` 처음 사용 해보았는데 대략적인 흐름을 알 수 있었고 몇 번 더 사용하면 익숙해질 것 같다.
- `RTK`와 `localStorage` 같이 사용해야 할 때 처음에는 막막했는데 평소 js로 localstorage 사용하는 것처럼 단순하게 생각하니 원하는대로 동작하였다. 