### PR TITLE
[FE] 회원 탈퇴 구현

### DIFF
--- a/client/src/common/components/Checkbox/CheckBoxList.tsx
+++ b/client/src/common/components/Checkbox/CheckBoxList.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { CATEGORY } from '../../constants';
-import CheckBox from './CheckBox';
+import CheckBox from './Checkbox';
 
 const CheckBoxList = () => {
   const [seletedCategories, setSelectedCategories] = useState<string[]>([]);

--- a/client/src/common/store/RootStore.tsx
+++ b/client/src/common/store/RootStore.tsx
@@ -6,7 +6,6 @@ import { interestProducts } from './InterestStore';
 import { monthlyReservation } from '../../pages/Booking/store/MonthlyReservationStore';
 import { mypageProfileSlice } from '../../pages/MyPage/store/ProfileSlice';
 
-
 const rootReducer = combineReducers({
   userInfo: userInfo.reducer,
   calendar: calendar.reducer,

--- a/client/src/common/utils/customHooks/useGetMe.tsx
+++ b/client/src/common/utils/customHooks/useGetMe.tsx
@@ -38,7 +38,7 @@ function useGetMe(): UseQueryResult<IUserInfo | null> {
         },
       );
 
-      console.log('3. getMe response:', data === '');
+      console.log('3. getMe response:', data);
 
       // 유저 정보 store에 저장
       dispatch(createUserInfo(data));

--- a/client/src/pages/Login/views/LoginPage.tsx
+++ b/client/src/pages/Login/views/LoginPage.tsx
@@ -7,7 +7,7 @@ function LoginPage() {
     try {
       console.log('회원탈퇴');
       const response = axios.delete(
-        process.env.REACT_APP_API_URL + '/api/members',
+        process.env.REACT_APP_API_URL + '/api/members/',
       );
       console.log(response);
     } catch (error) {

--- a/client/src/pages/MyPage/views/MyPage.tsx
+++ b/client/src/pages/MyPage/views/MyPage.tsx
@@ -23,7 +23,6 @@ const MyPage = () => {
   console.log('로그인 상태인가?', isLoggedIn);
   console.log('유저 정보', userInfo);
 
-
   const [profileData, setProfileData] = useState<ProfileDataType | undefined>(
     undefined,
   );


### PR DESCRIPTION
### 기능 요약
- 회원 탈퇴 DELETE 요청 보낼 시 401 에러가 뜨던 문제 해결

### 화면/테스트 결과
![스크린샷 2023-07-14 오후 1 23 58](https://github.com/codestates-seb/seb44_main_028/assets/117507731/4b7430b4-28f1-49fc-8318-fdba789af708)

### 배운점
- url 엔드포인트 뒤에 /를 빠뜨렸더니 401 오류가 났다. 앞으로 같은 실수를 하지 않게될 것 같다.
