### PR TITLE
[FE] detail Page 구현

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -15,7 +15,6 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "@types/jest": "^27.5.2",
-        "@types/node": "^16.18.38",
         "@types/react": "^18.2.14",
         "@types/react-dom": "^18.2.6",
         "axios": "^1.4.0",
@@ -41,6 +40,7 @@
       "devDependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
         "@types/crypto-js": "^4.1.1",
+        "@types/node": "^20.4.2",
         "@types/react-js-pagination": "^3.0.4",
         "@types/sockjs-client": "^1.5.1",
         "@types/styled-components": "^5.1.26",
@@ -4604,9 +4604,9 @@
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
     },
     "node_modules/@types/node": {
-      "version": "16.18.38",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.38.tgz",
-      "integrity": "sha512-6sfo1qTulpVbkxECP+AVrHV9OoJqhzCsfTNp5NIG+enM4HyM3HvZCO798WShIXBN0+QtDIcutJCjsVYnQP5rIQ=="
+      "version": "20.4.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.2.tgz",
+      "integrity": "sha512-Dd0BYtWgnWJKwO1jkmTrzofjK2QXXcai0dmtzvIBhcA+RsG5h8R3xlyta0kGOZRNfL9GuRtb1knmPEhQrePCEw=="
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -44,6 +44,7 @@
         "@types/crypto-js": "^4.1.1",
         "@types/node": "^20.4.2",
         "@types/react-js-pagination": "^3.0.4",
+        "@types/react-slick": "^0.23.10",
         "@types/sockjs-client": "^1.5.1",
         "@types/styled-components": "^5.1.26",
         "eslint-config-prettier": "^8.8.0",
@@ -4678,6 +4679,15 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/react-js-pagination/-/react-js-pagination-3.0.4.tgz",
       "integrity": "sha512-yka+27eZ6Mg9cmwT2sADgLn3ij9hVfpPu5dk+Y/0k1xS52WZOz0LJnn4y4VKGmR4mf/tG5Ga7Dody/xmfiB0Fg==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-slick": {
+      "version": "0.23.10",
+      "resolved": "https://registry.npmjs.org/@types/react-slick/-/react-slick-0.23.10.tgz",
+      "integrity": "sha512-ZiqdencANDZy6sWOWJ54LDvebuXFEhDlHtXU9FFipQR2BcYU2QJxZhvJPW6YK7cocibUiNn+YvDTbt1HtCIBVA==",
       "dev": true,
       "dependencies": {
         "@types/react": "*"

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -29,6 +29,7 @@
         "react-redux": "^8.1.0",
         "react-router-dom": "^6.13.0",
         "react-scripts": "5.0.1",
+        "react-slick": "^0.29.0",
         "react-spinners": "^0.13.8",
         "redux": "^4.2.1",
         "socket.io-client": "^4.7.1",
@@ -7551,6 +7552,11 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/enquire.js": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/enquire.js/-/enquire.js-2.1.6.tgz",
+      "integrity": "sha512-/KujNpO+PT63F7Hlpu4h3pE3TokKRHN26JYmQpPyjkRD/N57R7bPDNojMXdi7uveAKjYB7yQnartCxZnFWr0Xw=="
+    },
     "node_modules/entities": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
@@ -12402,6 +12408,14 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
     },
+    "node_modules/json2mq": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
+      "integrity": "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==",
+      "dependencies": {
+        "string-convert": "^0.2.0"
+      }
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -15502,6 +15516,22 @@
         }
       }
     },
+    "node_modules/react-slick": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.29.0.tgz",
+      "integrity": "sha512-TGdOKE+ZkJHHeC4aaoH85m8RnFyWqdqRfAGkhd6dirmATXMZWAxOpTLmw2Ll/jPTQ3eEG7ercFr/sbzdeYCJXA==",
+      "dependencies": {
+        "classnames": "^2.2.5",
+        "enquire.js": "^2.1.6",
+        "json2mq": "^0.2.0",
+        "lodash.debounce": "^4.0.8",
+        "resize-observer-polyfill": "^1.5.0"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-spinners": {
       "version": "0.13.8",
       "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.13.8.tgz",
@@ -15732,6 +15762,11 @@
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
       "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ=="
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "node_modules/resolve": {
       "version": "1.22.2",
@@ -16553,6 +16588,11 @@
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
+    },
+    "node_modules/string-convert": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
+      "integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A=="
     },
     "node_modules/string-length": {
       "version": "4.0.2",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -32,6 +32,7 @@
         "react-slick": "^0.29.0",
         "react-spinners": "^0.13.8",
         "redux": "^4.2.1",
+        "slick-carousel": "^1.8.1",
         "socket.io-client": "^4.7.1",
         "sockjs-client": "^1.6.1",
         "styled-components": "^5.3.11",
@@ -12310,6 +12311,12 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jquery": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.0.tgz",
+      "integrity": "sha512-umpJ0/k8X0MvD1ds0P9SfowREz2LenHsQaxSohMZ5OMNEU2r0tf8pdeEFTHMFxWVxKNyU9rTtK3CWzUCTKJUeQ==",
+      "peer": true
+    },
     "node_modules/js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
@@ -16371,6 +16378,14 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/slick-carousel": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/slick-carousel/-/slick-carousel-1.8.1.tgz",
+      "integrity": "sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA==",
+      "peerDependencies": {
+        "jquery": ">=1.8.0"
       }
     },
     "node_modules/socket.io-client": {

--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,6 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "@types/jest": "^27.5.2",
-    "@types/node": "^16.18.38",
     "@types/react": "^18.2.14",
     "@types/react-dom": "^18.2.6",
     "axios": "^1.4.0",
@@ -60,6 +59,7 @@
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@types/crypto-js": "^4.1.1",
+    "@types/node": "^20.4.2",
     "@types/react-js-pagination": "^3.0.4",
     "@types/sockjs-client": "^1.5.1",
     "@types/styled-components": "^5.1.26",

--- a/client/package.json
+++ b/client/package.json
@@ -27,6 +27,7 @@
     "react-slick": "^0.29.0",
     "react-spinners": "^0.13.8",
     "redux": "^4.2.1",
+    "slick-carousel": "^1.8.1",
     "socket.io-client": "^4.7.1",
     "sockjs-client": "^1.6.1",
     "styled-components": "^5.3.11",

--- a/client/package.json
+++ b/client/package.json
@@ -63,6 +63,7 @@
     "@types/crypto-js": "^4.1.1",
     "@types/node": "^20.4.2",
     "@types/react-js-pagination": "^3.0.4",
+    "@types/react-slick": "^0.23.10",
     "@types/sockjs-client": "^1.5.1",
     "@types/styled-components": "^5.1.26",
     "eslint-config-prettier": "^8.8.0",

--- a/client/package.json
+++ b/client/package.json
@@ -24,6 +24,7 @@
     "react-redux": "^8.1.0",
     "react-router-dom": "^6.13.0",
     "react-scripts": "5.0.1",
+    "react-slick": "^0.29.0",
     "react-spinners": "^0.13.8",
     "redux": "^4.2.1",
     "socket.io-client": "^4.7.1",

--- a/client/src/Router.tsx
+++ b/client/src/Router.tsx
@@ -19,14 +19,14 @@ function Router() {
       <Route path="/login" element={<LoginPage />} />
       <Route path="/auth/callback" element={<RedirectPage />} />
       <Route path="/itemlist/:categoryId" element={<ItemListPage />} />
-      <Route element={<PrivateRoutes />}>
-        <Route path="/booking/:itemId" element={<BookingPage />} />
-        <Route path="/mypage" element={<MyPage />} />
-        <Route path="/mypage/edit" element={<ProfileEdit />} />
-        <Route path="/create" element={<CreatePage />} />
-        <Route path="/update/:itemId" element={<UpdatePage />} />
-        <Route path="/chatting/:roomId" element={<ChattingPage />} />
-      </Route>
+      {/* <Route element={<PrivateRoutes />}> */}
+      <Route path="/booking/:itemId" element={<BookingPage />} />
+      <Route path="/mypage" element={<MyPage />} />
+      <Route path="/mypage/edit" element={<ProfileEdit />} />
+      <Route path="/create" element={<CreatePage />} />
+      <Route path="/update/:itemId" element={<UpdatePage />} />
+      <Route path="/chatting/:roomId" element={<ChattingPage />} />
+      {/* </Route> */}
       <Route path="/detail/:itemId" element={<DetailPage />} />
     </Routes>
   );

--- a/client/src/common/components/Checkbox/CheckBoxList.tsx
+++ b/client/src/common/components/Checkbox/CheckBoxList.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useState } from 'react';
 import { useQuery } from 'react-query';
 import axios from 'axios';
@@ -6,8 +7,7 @@ import { CategoryListProps } from '../../type';
 import { ICategory } from '../../model/ICategory';
 import Loading from '../Loading';
 import ErrorPage from '../ErrorPage';
-import CheckBox from './Checkbox';
-        
+
 const CheckBoxList = ({
   selectedtCategory,
   setSelectedCategory,

--- a/client/src/common/components/Checkbox/Checkbox.tsx
+++ b/client/src/common/components/Checkbox/Checkbox.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { CheckBoxWrapper } from '../../style/style';
 import { CheckBoxProps } from '../../type';
 

--- a/client/src/common/utils/customHooks/useGetMe.tsx
+++ b/client/src/common/utils/customHooks/useGetMe.tsx
@@ -56,7 +56,7 @@ function useGetMe(): UseQueryResult<IUserInfo | null> {
         console.log('5. 재발급 받은 accessToken:', newAccessToken);
         localStorage.setItem(ACCESS_TOKEN, encryptToken(newAccessToken));
       }
-       return data;
+      return data;
     } catch (error: AxiosError | any) {
       console.log('error가 난거니? 뭠미?', error.response.status);
       const statusCode = error.response.status;

--- a/client/src/pages/Detail/components/ChatBtn.tsx
+++ b/client/src/pages/Detail/components/ChatBtn.tsx
@@ -2,6 +2,8 @@ import axios from 'axios';
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import useGetMe from '../../../common/utils/customHooks/useGetMe';
+import BigDefaultBtn from '../../../common/components/Button';
+import { colorPalette } from '../../../common/utils/enum/colorPalette';
 
 function makeChatRoomName(senderId: number, receiverId: number) {
   const chatRoomName = [String(senderId), String(receiverId)].sort().join('');
@@ -60,6 +62,17 @@ function ChatBtn() {
     }
   };
 
-  return <button onClick={createChatRoom}>채팅하기</button>;
+  return (
+    <BigDefaultBtn
+      color="inherit"
+      backgroundColor={colorPalette.modalCancelButtonColor}
+      hoverBackgroundColor={colorPalette.modalCancelHoverColor}
+      height={64}
+      width={100}
+      onClick={createChatRoom}
+    >
+      채팅하기
+    </BigDefaultBtn>
+  );
 }
 export default ChatBtn;

--- a/client/src/pages/Detail/components/ImageCarousel.tsx
+++ b/client/src/pages/Detail/components/ImageCarousel.tsx
@@ -15,15 +15,17 @@ const ImageCarousel = ({ images }: { images: string[] }) => {
     centerMode: true,
     centerPadding: '0px', // 0px 하면 슬라이드 사이에 여백이 없어짐
   };
-  // console.log(images);
+  console.log(images);
+  console.log(images.reverse());
+  //const reversedArray = array.map((_, index, arr) => arr[arr.length - 1 - index]);
   return (
     <ImageCarouselContainer>
       <div>
         <Slider {...settings}>
-          {images.map((image, index) => {
+          {images.map((_, index, image) => {
             return (
               <ItemImageBox key={index}>
-                <img src={image} />
+                <img src={image[image.length - 1 - index]} />
               </ItemImageBox>
             );
           })}

--- a/client/src/pages/Detail/components/ImageCarousel.tsx
+++ b/client/src/pages/Detail/components/ImageCarousel.tsx
@@ -1,18 +1,36 @@
-import { ImageCarouselContainer } from '../style';
+import { ImageCarouselContainer, ItemImageBox } from '../style';
+import Slider from 'react-slick';
 
 const ImageCarousel = ({ images }: { images: string[] }) => {
-  // const settings = {
-  //   dots: true,
-  //   infinite: true,
-  //   speed: 500,
-  //   autoplay: true,
-  //   autoplaySpeed: 3000,
-  //   slidesToShow: 1,
-  //   slidesToScroll: 1,
-  //   centerMode: true,
-  //   centerPadding: '20px',
-  // };
-  // return <ImageCarouselContainer {...settings}>{i}</ImageCarouselContainer>;
+  const settings = {
+    dots: true, // 슬라이드 밑에 점 보이게
+    infinite: true, // 무한으로 반복
+    pauseOnHover: true,
+    speed: 500,
+    arrows: true,
+    autoplay: true,
+    autoplaySpeed: 3000, // 넘어가는 속도
+    slidesToShow: 1, // 1장씩 보이게
+    slidesToScroll: 1, //한장씩 뒤로 넘어가게
+    centerMode: true,
+    centerPadding: '0px', // 0px 하면 슬라이드 사이에 여백이 없어짐
+  };
+  // console.log(images);
+  return (
+    <ImageCarouselContainer>
+      <div>
+        <Slider {...settings}>
+          {images.map((image, index) => {
+            return (
+              <ItemImageBox key={index}>
+                <img src={image} />
+              </ItemImageBox>
+            );
+          })}
+        </Slider>
+      </div>
+    </ImageCarouselContainer>
+  );
 };
 
 export default ImageCarousel;

--- a/client/src/pages/Detail/components/ImageCarousel.tsx
+++ b/client/src/pages/Detail/components/ImageCarousel.tsx
@@ -1,0 +1,18 @@
+import { ImageCarouselContainer } from '../style';
+
+const ImageCarousel = ({ images }: { images: string[] }) => {
+  // const settings = {
+  //   dots: true,
+  //   infinite: true,
+  //   speed: 500,
+  //   autoplay: true,
+  //   autoplaySpeed: 3000,
+  //   slidesToShow: 1,
+  //   slidesToScroll: 1,
+  //   centerMode: true,
+  //   centerPadding: '20px',
+  // };
+  // return <ImageCarouselContainer {...settings}>{i}</ImageCarouselContainer>;
+};
+
+export default ImageCarousel;

--- a/client/src/pages/Detail/components/ItemContent.tsx
+++ b/client/src/pages/Detail/components/ItemContent.tsx
@@ -31,12 +31,13 @@ import Loading from '../../../common/components/Loading';
 import ErrorPage from '../../../common/components/ErrorPage';
 import ChatBtn from './ChatBtn';
 import { ICategory } from '../type';
+import ImageCarousel from './ImageCarousel';
 
 const ItemContent = () => {
   const [ratingIndex, setRatingIndex] = useState(3);
   const navigate = useNavigate();
   const param = useParams();
-  console.log(param);
+
   const handleReservation = () => {
     navigate(`/booking/${param.itemId}`);
   };
@@ -68,7 +69,7 @@ const ItemContent = () => {
       <ItemInfoWrapper>
         {/* <ItemImageWrapper images={data.images}> */}
         <ItemImageWrapper>
-          <img src={data.productImages[0]} />
+          <ImageCarousel images={data.productImages} />
         </ItemImageWrapper>
         <ItemUserWrapper>
           {/* 유저 정보 */}
@@ -126,8 +127,14 @@ const ItemContent = () => {
             ))}
           </ItemTagSection>
           <ProductBtn>
-            <div onClick={handleUpdate}>{USER_BTN[0]}</div>
-            <div onClick={handleDelete}>{USER_BTN[1]}</div>
+            {data.isOwner ? (
+              <>
+                <div onClick={handleUpdate}>{USER_BTN[0]}</div>
+                <div onClick={handleDelete}>{USER_BTN[1]}</div>
+              </>
+            ) : (
+              <div></div>
+            )}
           </ProductBtn>
         </ProductDescription>
       </ItemDescriptionWrapper>

--- a/client/src/pages/Detail/components/ItemContent.tsx
+++ b/client/src/pages/Detail/components/ItemContent.tsx
@@ -36,7 +36,7 @@ const ItemContent = () => {
   const [ratingIndex, setRatingIndex] = useState(3);
   const navigate = useNavigate();
   const param = useParams();
-
+  console.log(param);
   const handleReservation = () => {
     navigate(`/booking/${param.itemId}`);
   };
@@ -51,7 +51,7 @@ const ItemContent = () => {
   };
   const { data, isLoading, error } = useQuery('productDtail', async () => {
     const { data } = await axios.get(
-      `${process.env.REACT_APP_API_URL}/api/products/018cc66f-9361-4fff-8a41-87ed5fd50d4b`,
+      `${process.env.REACT_APP_API_URL}/api/products/${param.itemId}`,
     );
     console.log(data);
     return data;
@@ -66,8 +66,9 @@ const ItemContent = () => {
   return (
     <ItemContentContainer>
       <ItemInfoWrapper>
+        {/* <ItemImageWrapper images={data.images}> */}
         <ItemImageWrapper>
-          <img src={data.images[0]} />
+          <img src={data.productImages[0]} />
         </ItemImageWrapper>
         <ItemUserWrapper>
           {/* 유저 정보 */}
@@ -101,7 +102,7 @@ const ItemContent = () => {
             >
               예약하기
             </BigDefaultBtn>
-            <ChatBtn />
+            {/* <ChatBtn /> */}
           </ItemActionBtn>
         </ItemUserWrapper>
       </ItemInfoWrapper>

--- a/client/src/pages/Detail/components/ItemContent.tsx
+++ b/client/src/pages/Detail/components/ItemContent.tsx
@@ -28,6 +28,7 @@ import { ITEM_PRICE, ITEM_TAG, ITEM_NOTICE, USER_BTN } from '../constants';
 import Loading from '../../../common/components/Loading';
 import ErrorPage from '../../../common/components/ErrorPage';
 import ChatBtn from './ChatBtn';
+import { ICategory } from '../type';
 
 const ItemContent = () => {
   const [ratingIndex, setRatingIndex] = useState(3);
@@ -113,9 +114,9 @@ const ItemContent = () => {
           <ProductNotice>{ITEM_NOTICE}</ProductNotice>
           {/* 카테고리 */}
           <ItemTagSection>
-            {/* {data.categories.map((tag) => (
+            {data?.categories.map((tag: ICategory) => (
               <ItemTag key={tag.categoryId} itemtag={tag.title} />
-            ))} */}
+            ))}
           </ItemTagSection>
           <ProductBtn>
             <div onClick={handleUpdate}>{USER_BTN[0]}</div>

--- a/client/src/pages/Detail/components/ItemContent.tsx
+++ b/client/src/pages/Detail/components/ItemContent.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useQuery } from 'react-query';
 import axios from 'axios';
+import { GrFormView } from 'react-icons/gr';
 import ItemUserInfo from './ItemUserInfo';
 import ItemPrice from './ItemPrice';
 import RatingStar from '../../MyPage/components/RatingStar';
@@ -16,6 +17,7 @@ import {
   ItemRate,
   ItemTagSection,
   ItemActionBtn,
+  ProductView,
   ProductDescription,
   ProductInfo,
   ProductTitle,
@@ -108,6 +110,10 @@ const ItemContent = () => {
           <div>상품정보</div>
           <div></div>
         </ProductInfo>
+        <ProductView>
+          <GrFormView />
+          <div>{data.viewCount}</div>
+        </ProductView>
         <ProductDescription>
           <ProductTitle>{data.title}</ProductTitle>
           <ProductContent>{data.content}</ProductContent>

--- a/client/src/pages/Detail/components/ItemContent.tsx
+++ b/client/src/pages/Detail/components/ItemContent.tsx
@@ -1,4 +1,6 @@
 import { useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useQuery } from 'react-query';
 import axios from 'axios';
 import ItemUserInfo from './ItemUserInfo';
 import ItemPrice from './ItemPrice';
@@ -23,10 +25,9 @@ import {
 } from '../style';
 import { colorPalette } from '../../../common/utils/enum/colorPalette';
 import { ITEM_PRICE, ITEM_TAG, ITEM_NOTICE, USER_BTN } from '../constants';
-import { useNavigate, useParams } from 'react-router-dom';
-import { useQuery } from 'react-query';
 import Loading from '../../../common/components/Loading';
 import ErrorPage from '../../../common/components/ErrorPage';
+import ChatBtn from './ChatBtn';
 
 const ItemContent = () => {
   const [ratingIndex, setRatingIndex] = useState(3);
@@ -67,7 +68,7 @@ const ItemContent = () => {
         </ItemImageWrapper>
         <ItemUserWrapper>
           {/* 유저 정보 */}
-          <ItemUserInfo userName={data.userName} address={data.address} />
+          <ItemUserInfo userName={data.username} address={data.address} />
           {/* 가격 정보 */}
 
           <ItemPrice
@@ -92,12 +93,12 @@ const ItemContent = () => {
               backgroundColor={colorPalette.heavyColor}
               hoverBackgroundColor={colorPalette.rightButtonHoverColor}
               height={64}
-              width={228}
+              width={198}
               onClick={handleReservation}
             >
               예약하기
             </BigDefaultBtn>
-            <div onClick={handleChatting}>채팅아이콘</div>
+            <ChatBtn />
           </ItemActionBtn>
         </ItemUserWrapper>
       </ItemInfoWrapper>

--- a/client/src/pages/Detail/style.ts
+++ b/client/src/pages/Detail/style.ts
@@ -92,6 +92,16 @@ export const ProductBtn = styled.div`
   }
 `;
 
+export const ProductView = styled.div`
+  margin-top: 1rem;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  & div {
+    font-size: ${fontSize.small};
+    color: ${colorPalette.detailPageGrayColor};
+  }
+`;
 export const ItemUserInfoContainer = styled.div`
   display: flex;
   margin-bottom: 2.5rem;

--- a/client/src/pages/Detail/style.ts
+++ b/client/src/pages/Detail/style.ts
@@ -150,3 +150,4 @@ export const ItemTagWrapper = styled.div`
   color: ${colorPalette.whiteColor};
   margin-right: 1rem;
 `;
+export const ImageCarouselContainer = styled.div``;

--- a/client/src/pages/Detail/style.ts
+++ b/client/src/pages/Detail/style.ts
@@ -37,7 +37,9 @@ export const ItemRate = styled.div`
   margin-left: 1rem;
 `;
 export const ItemActionBtn = styled.div`
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
   margin-top: 1.938rem;
 `;
 export const ItemDescriptionWrapper = styled.div`

--- a/client/src/pages/Detail/style.ts
+++ b/client/src/pages/Detail/style.ts
@@ -1,7 +1,10 @@
 import styled from 'styled-components';
+import 'slick-carousel/slick/slick.css';
+import 'slick-carousel/slick/slick-theme.css';
 import { fontSize } from '../../common/utils/enum/fontSize';
 import { colorPalette } from '../../common/utils/enum/colorPalette';
 import { border } from '../../common/utils/enum/border';
+import Slider from 'react-slick';
 
 export const ItemContentContainer = styled.div`
   display: flex;
@@ -150,4 +153,37 @@ export const ItemTagWrapper = styled.div`
   color: ${colorPalette.whiteColor};
   margin-right: 1rem;
 `;
-export const ImageCarouselContainer = styled.div``;
+export const StyledSlider = styled(Slider)`
+  width: 49.5rem;
+  height: 33.75rem;
+  margin-right: 0;
+
+  .slick-slide div {
+    cursor: pointer;
+  }
+  .slick-slide img {
+    object-fit: cover;
+  }
+  .slick-prev::before,
+  .slick-next::before {
+    width: 35px;
+    height: 35px;
+    z-index: 2;
+    background-color: black;
+  }
+`;
+
+export const ImageCarouselContainer = styled.div`
+  width: 49.5rem;
+  height: 33.75rem;
+  ul {
+    transform: translateY(-2.5rem);
+  }
+`;
+export const ItemImageBox = styled.div`
+  & img {
+    margin-right: 0;
+    width: 49.5rem;
+    height: 33.75rem;
+  }
+`;

--- a/client/src/pages/Detail/type.ts
+++ b/client/src/pages/Detail/type.ts
@@ -6,3 +6,7 @@ export type ItemPriceProps = {
   itemKey: string;
   itemValue: string | number;
 };
+export interface ICategory {
+  categoryId: string;
+  title: string;
+}


### PR DESCRIPTION
### 기능 요약
- 글 작성하면 상세 페이지로 이동
- 서버에서 받아온 내용 파싱
- 글을 쓴 멤버만 `수정, 삭제` 버튼 보이게 구현
- `react-slick`을 사용하여 이미지 슬라이드 구현
  - hover 하면 이미지 멈춤
  
### 화면/테스트 결과

https://github.com/codestates-seb/seb44_main_028/assets/72354092/1b2d14da-83f4-48cc-812a-c98aac85d7e6

![Jul-17-2023 05-31-24](https://github.com/codestates-seb/seb44_main_028/assets/72354092/9760e17f-5ebf-49d3-a9ab-b426427a4186)

### 배운점
- `react-slick` 을 사용해 보았는데 내가 생각한 것 보다 css로 커스텀 하는 부분이 쉽지 않았다.