### PR TITLE
[FE] search Page

### DIFF
--- a/client/src/Router.tsx
+++ b/client/src/Router.tsx
@@ -20,7 +20,7 @@ function Router() {
       <Route path="/login" element={<LoginPage />} />
       <Route path="/auth/callback" element={<RedirectPage />} />
       <Route path="/itemlist/:categoryId" element={<ItemListPage />} />
-      <Route path="/itemlist/search/:serachContent" element={<SearchPage />} />
+      <Route path="/itemlist/search/:searchContent" element={<SearchPage />} />
       {/* <Route element={<PrivateRoutes />}> */}
       <Route path="/booking/:itemId" element={<BookingPage />} />
       <Route path="/mypage" element={<MyPage />} />

--- a/client/src/Router.tsx
+++ b/client/src/Router.tsx
@@ -9,6 +9,7 @@ import CreatePage from './pages/Create/views/CreatePage';
 import UpdatePage from './pages/Update/views/UpdatePage';
 import ChattingPage from './pages/Chatting/views/ChattingPage';
 import BookingPage from './pages/Booking/views/BookingPage';
+import SearchPage from './pages/Search/views/SearchPage';
 import PrivateRoutes from './PrivateRoutes';
 import ProfileEdit from './pages/MyPage/components/ProfileEdit';
 
@@ -19,6 +20,7 @@ function Router() {
       <Route path="/login" element={<LoginPage />} />
       <Route path="/auth/callback" element={<RedirectPage />} />
       <Route path="/itemlist/:categoryId" element={<ItemListPage />} />
+      <Route path="/itemlist/search/:serachContent" element={<SearchPage />} />
       {/* <Route element={<PrivateRoutes />}> */}
       <Route path="/booking/:itemId" element={<BookingPage />} />
       <Route path="/mypage" element={<MyPage />} />

--- a/client/src/common/components/ItemCard/ItemCard.tsx
+++ b/client/src/common/components/ItemCard/ItemCard.tsx
@@ -78,7 +78,7 @@ const ItemCard = ({ itemCardData }: { itemCardData: ItemCardProps }) => {
   };
   return (
     <ItemCardContainer onClick={handleItemOnClick}>
-      <ItemImage src={itemCardData.images}></ItemImage>
+      <ItemImage src={itemCardData.image}></ItemImage>
       <ItemInfo>
         <ItemName>{itemCardData.title}</ItemName>
         <ItemDescription>{itemCardData.content}</ItemDescription>

--- a/client/src/common/components/ItemCard/ItemCard.tsx
+++ b/client/src/common/components/ItemCard/ItemCard.tsx
@@ -33,7 +33,7 @@ const ItemCard = ({ itemCardData }: { itemCardData: ItemCardProps }) => {
     localStorage.setItem(INTEREST_KEY, JSON.stringify(interestItems));
   }, [interestItems]);
 
-  const isInterest = interestItems.includes(itemCardData.id);
+  const isInterest = interestItems.includes(itemCardData.productId);
   const addInterestMutation = useMutation((productId: string) =>
     axios
       .post(`${process.env.REACT_APP_API_URL}/api/members/interests`, {
@@ -64,15 +64,17 @@ const ItemCard = ({ itemCardData }: { itemCardData: ItemCardProps }) => {
     if (isInterest) {
       removeInterestMutation.mutate(interestId);
       dispatch(removeInterest(interestId));
-      setInterestItems(interestItems.filter((id) => id !== itemCardData.id));
+      setInterestItems(
+        interestItems.filter((id) => id !== itemCardData.productId),
+      );
     } else {
-      addInterestMutation.mutate(itemCardData.id);
-      dispatch(addInterest(itemCardData.id));
-      setInterestItems([...interestItems, itemCardData.id]);
+      addInterestMutation.mutate(itemCardData.productId);
+      dispatch(addInterest(itemCardData.productId));
+      setInterestItems([...interestItems, itemCardData.productId]);
     }
   };
   const handleItemOnClick = () => {
-    navigate(`/detail/${itemCardData.id}`);
+    navigate(`/detail/${itemCardData.productId}`);
   };
   return (
     <ItemCardContainer onClick={handleItemOnClick}>

--- a/client/src/common/components/ItemCard/ItemCardList.tsx
+++ b/client/src/common/components/ItemCard/ItemCardList.tsx
@@ -11,7 +11,7 @@ const ItemCardList = ({
       <p>{itemCardListTitle}</p>
       <ItemCardWrapper>
         {itemCardListContentData.map((itemcard) => (
-          <ItemCard key={itemcard.id} itemCardData={itemcard} />
+          <ItemCard key={itemcard.productId} itemCardData={itemcard} />
         ))}
       </ItemCardWrapper>
     </ItemCardListWrapper>

--- a/client/src/common/type.ts
+++ b/client/src/common/type.ts
@@ -60,7 +60,7 @@ export type ItemCardProps = {
   category: number[];
   address: string;
   minRental: number;
-  images: string;
+  image: string;
 };
 
 // export type BorrowCardProps = {

--- a/client/src/common/type.ts
+++ b/client/src/common/type.ts
@@ -50,7 +50,7 @@ export type ItemCardListProps = {
   itemCardListContentData: ItemCardProps[];
 };
 export type ItemCardProps = {
-  id: string;
+  productId: string;
   title: string;
   baseFee: number;
   feePerDay: number;

--- a/client/src/pages/Create/components/WritePost.tsx
+++ b/client/src/pages/Create/components/WritePost.tsx
@@ -10,7 +10,7 @@ import { BsCheckLg } from 'react-icons/bs';
 import { BiErrorCircle } from 'react-icons/bi';
 import UploadImage from '../components/UploadImage';
 import ModalMain from '../../../common/components/Modal/ModalMain';
-import CheckBoxList from '../../../common/components/CheckBox/CheckBoxList';
+import CheckBoxList from '../../../common/components/Checkbox/CheckBoxList';
 import {
   CONTENT_DESCRIPTION,
   INPIT_VALIDATION,

--- a/client/src/pages/Header/views/Header.tsx
+++ b/client/src/pages/Header/views/Header.tsx
@@ -34,7 +34,12 @@ function Header() {
     }
     navigate('/login');
   };
-
+  const handelSearch = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    const searchContent = (e.target as HTMLInputElement).value;
+    if (e.key === 'Enter') {
+      navigate(`/itemlist/search/${searchContent}`);
+    }
+  };
   return (
     <HeaderContainer>
       <LogoWrapper>
@@ -50,7 +55,7 @@ function Header() {
         </ol>
         <NavIconWrapper>
           <NavSearchForm isClick={isClick}>
-            <input type="text" />
+            <input type="text" onKeyDown={handelSearch} />
             <MdSearch onClick={handleClick} />
           </NavSearchForm>
           <NavSendIconWrapper>

--- a/client/src/pages/ItemList/views/ItemListPage.tsx
+++ b/client/src/pages/ItemList/views/ItemListPage.tsx
@@ -60,7 +60,7 @@ function ItemListPage() {
         </div>
       }
       {products?.map((product: ItemCardProps) => (
-        <ItemCard key={product.id} itemCardData={product} />
+        <ItemCard key={product.productId} itemCardData={product} />
       ))}
     </ItemListPageContainer>
   );

--- a/client/src/pages/Main/constants.ts
+++ b/client/src/pages/Main/constants.ts
@@ -33,7 +33,7 @@ export const ITEMCARDLIST_TITLE: string[] = [
 ];
 export const ITEMCARD_DATA: ItemCardProps[] = [
   {
-    id: '86911664-5691-4fb3-b441-04e1eca38fb7',
+    productId: '86911664-5691-4fb3-b441-04e1eca38fb7',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,
@@ -48,7 +48,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
-    id: '97c61b71-f91f-47f8-8737-7e4e15cdb36f',
+    productId: '97c61b71-f91f-47f8-8737-7e4e15cdb36f',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,
@@ -63,7 +63,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
-    id: '506d3643-573f-4347-b51f-36cc7abcbccb',
+    productId: '506d3643-573f-4347-b51f-36cc7abcbccb',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,
@@ -80,7 +80,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
 ];
 export const ITEMCARD_DEVELOPMENT_DATA: ItemCardProps[] = [
   {
-    id: '1',
+    productId: '1',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,
@@ -95,7 +95,7 @@ export const ITEMCARD_DEVELOPMENT_DATA: ItemCardProps[] = [
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
-    id: '2',
+    productId: '2',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,
@@ -110,7 +110,7 @@ export const ITEMCARD_DEVELOPMENT_DATA: ItemCardProps[] = [
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
-    id: '3',
+    productId: '3',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,
@@ -125,7 +125,7 @@ export const ITEMCARD_DEVELOPMENT_DATA: ItemCardProps[] = [
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
-    id: '4',
+    productId: '4',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,
@@ -140,7 +140,7 @@ export const ITEMCARD_DEVELOPMENT_DATA: ItemCardProps[] = [
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
-    id: '5',
+    productId: '5',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,
@@ -155,7 +155,7 @@ export const ITEMCARD_DEVELOPMENT_DATA: ItemCardProps[] = [
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
-    id: '6',
+    productId: '6',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,

--- a/client/src/pages/Main/constants.ts
+++ b/client/src/pages/Main/constants.ts
@@ -44,7 +44,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
     category: [1, 2, 3],
     address: '동대문구 마장동',
     minRental: 3,
-    images:
+    image:
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
@@ -59,7 +59,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
     category: [1, 2, 3],
     address: '동대문구 마장동',
     minRental: 3,
-    images:
+    image:
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
@@ -74,7 +74,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
     category: [1, 2, 3],
     address: '동대문구 마장동',
     minRental: 3,
-    images:
+    image:
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
 ];
@@ -91,7 +91,7 @@ export const ITEMCARD_DEVELOPMENT_DATA: ItemCardProps[] = [
     category: [1, 2, 3],
     address: '동대문구 마장동',
     minRental: 3,
-    images:
+    image:
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
@@ -106,7 +106,7 @@ export const ITEMCARD_DEVELOPMENT_DATA: ItemCardProps[] = [
     category: [1, 2, 3],
     address: '동대문구 마장동',
     minRental: 3,
-    images:
+    image:
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
@@ -121,7 +121,7 @@ export const ITEMCARD_DEVELOPMENT_DATA: ItemCardProps[] = [
     category: [1, 2, 3],
     address: '동대문구 마장동',
     minRental: 3,
-    images:
+    image:
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
@@ -136,7 +136,7 @@ export const ITEMCARD_DEVELOPMENT_DATA: ItemCardProps[] = [
     category: [1, 2, 3],
     address: '동대문구 마장동',
     minRental: 3,
-    images:
+    image:
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
@@ -151,7 +151,7 @@ export const ITEMCARD_DEVELOPMENT_DATA: ItemCardProps[] = [
     category: [1, 2, 3],
     address: '동대문구 마장동',
     minRental: 3,
-    images:
+    image:
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
@@ -166,7 +166,7 @@ export const ITEMCARD_DEVELOPMENT_DATA: ItemCardProps[] = [
     category: [1, 2, 3],
     address: '동대문구 마장동',
     minRental: 3,
-    images:
+    image:
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
 ];

--- a/client/src/pages/MyPage/constants.ts
+++ b/client/src/pages/MyPage/constants.ts
@@ -255,7 +255,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
     category: [1, 2, 3],
     address: '동대문구 마장동',
     minRental: 3,
-    images:
+    image:
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
@@ -270,7 +270,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
     category: [1, 2, 3],
     address: '동대문구 마장동',
     minRental: 3,
-    images:
+    image:
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
@@ -285,7 +285,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
     category: [1, 2, 3],
     address: '동대문구 마장동',
     minRental: 3,
-    images:
+    image:
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
@@ -300,7 +300,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
     category: [1, 2, 3],
     address: '동대문구 마장동',
     minRental: 3,
-    images:
+    image:
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
@@ -315,7 +315,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
     category: [1, 2, 3],
     address: '동대문구 마장동',
     minRental: 3,
-    images:
+    image:
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
@@ -330,7 +330,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
     category: [1, 2, 3],
     address: '동대문구 마장동',
     minRental: 3,
-    images:
+    image:
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
@@ -345,7 +345,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
     category: [1, 2, 3],
     address: '동대문구 마장동',
     minRental: 3,
-    images:
+    image:
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
@@ -360,7 +360,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
     category: [1, 2, 3],
     address: '동대문구 마장동',
     minRental: 3,
-    images:
+    image:
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
@@ -375,7 +375,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
     category: [1, 2, 3],
     address: '동대문구 마장동',
     minRental: 3,
-    images:
+    image:
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
@@ -390,7 +390,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
     category: [1, 2, 3],
     address: '동대문구 마장동',
     minRental: 3,
-    images:
+    image:
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
@@ -405,7 +405,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
     category: [1, 2, 3],
     address: '동대문구 마장동',
     minRental: 3,
-    images:
+    image:
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
 ];

--- a/client/src/pages/MyPage/constants.ts
+++ b/client/src/pages/MyPage/constants.ts
@@ -244,7 +244,7 @@ export const BORROWCARD_DATA: borrowCardProps[] = [
 
 export const ITEMCARD_DATA: ItemCardProps[] = [
   {
-    id: '2',
+    productId: '2',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,
@@ -259,7 +259,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
-    id: '3',
+    productId: '3',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,
@@ -274,7 +274,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
-    id: '4',
+    productId: '4',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,
@@ -289,7 +289,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
-    id: '5',
+    productId: '5',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,
@@ -304,7 +304,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
-    id: '6',
+    productId: '6',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,
@@ -319,7 +319,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
-    id: '7',
+    productId: '7',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,
@@ -334,7 +334,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
-    id: '8',
+    productId: '8',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,
@@ -349,7 +349,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
-    id: '9',
+    productId: '9',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,
@@ -364,7 +364,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
-    id: '10',
+    productId: '10',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,
@@ -379,7 +379,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
-    id: '11',
+    productId: '11',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,
@@ -394,7 +394,7 @@ export const ITEMCARD_DATA: ItemCardProps[] = [
       'https://image.newdaily.co.kr/site/data/img/2019/12/03/2019120300097_0.jpg',
   },
   {
-    id: '12',
+    productId: '12',
     title: '다이슨 빌려줍니다.',
     baseFee: 10000,
     feePerDay: 5000,

--- a/client/src/pages/Search/style.ts
+++ b/client/src/pages/Search/style.ts
@@ -2,4 +2,9 @@ import styled from 'styled-components';
 export const SearchPageContainer = styled.div`
   margin-top: 5.375rem;
 `;
-export const SearchProductListWrapper = styled.div``;
+export const SearchProductListWrapper = styled.div`
+  margin-top: 4.5rem;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 2rem 0;
+`;

--- a/client/src/pages/Search/style.ts
+++ b/client/src/pages/Search/style.ts
@@ -1,0 +1,5 @@
+import styled from 'styled-components';
+export const SearchPageContainer = styled.div`
+  margin-top: 5.375rem;
+`;
+export const SearchProductListWrapper = styled.div``;

--- a/client/src/pages/Search/views/SearchPage.tsx
+++ b/client/src/pages/Search/views/SearchPage.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const SearchPage = () => {
+  return <div></div>;
+};
+
+export default SearchPage;

--- a/client/src/pages/Search/views/SearchPage.tsx
+++ b/client/src/pages/Search/views/SearchPage.tsx
@@ -1,7 +1,23 @@
-import React from 'react';
-
+import SelectBox from '../../../common/components/SelectBox';
+import {
+  DISTANCE_DEFAULT_VALUE,
+  DISTANCE_OPTIONS,
+  PRODUCT_FILTER_OPTIONS,
+} from '../../../common/constants';
+import { SearchPageContainer, SearchProductListWrapper } from '../style';
 const SearchPage = () => {
-  return <div></div>;
+  return (
+    <SearchPageContainer>
+      <div>
+        <SelectBox
+          selectOptionData={DISTANCE_OPTIONS}
+          selectDefaultOption={DISTANCE_DEFAULT_VALUE}
+        />
+        <SelectBox selectOptionData={PRODUCT_FILTER_OPTIONS} />
+      </div>
+      <SearchProductListWrapper></SearchProductListWrapper>
+    </SearchPageContainer>
+  );
 };
 
 export default SearchPage;

--- a/client/src/pages/Search/views/SearchPage.tsx
+++ b/client/src/pages/Search/views/SearchPage.tsx
@@ -1,4 +1,10 @@
+import { useParams } from 'react-router-dom';
+import { useState } from 'react';
+import { useQuery } from 'react-query';
+import axios from 'axios';
 import SelectBox from '../../../common/components/SelectBox';
+import ItemCard from '../../../common/components/ItemCard/ItemCard';
+import { ItemCardProps } from '../../../common/type';
 import {
   DISTANCE_DEFAULT_VALUE,
   DISTANCE_OPTIONS,
@@ -6,6 +12,28 @@ import {
 } from '../../../common/constants';
 import { SearchPageContainer, SearchProductListWrapper } from '../style';
 const SearchPage = () => {
+  const params = useParams();
+  const [page, setPage] = useState(0);
+  const size = 10;
+  const { data, isLoading, error } = useQuery('searchProduct', async () => {
+    try {
+      const res = await axios.get(
+        `${process.env.REACT_APP_API_URL}/api/products/search`,
+        {
+          params: {
+            keyword: params.searchContent,
+            page: page,
+            size: size,
+          },
+        },
+      );
+      console.log('res', res);
+      return res.data;
+    } catch (err) {
+      console.log('err', err);
+    }
+  });
+
   return (
     <SearchPageContainer>
       <div>
@@ -15,7 +43,11 @@ const SearchPage = () => {
         />
         <SelectBox selectOptionData={PRODUCT_FILTER_OPTIONS} />
       </div>
-      <SearchProductListWrapper></SearchProductListWrapper>
+      <SearchProductListWrapper>
+        {data?.products.map((item: ItemCardProps) => (
+          <ItemCard key={item.productId} itemCardData={item} />
+        ))}
+      </SearchProductListWrapper>
     </SearchPageContainer>
   );
 };

--- a/client/src/pages/Search/views/SearchPage.tsx
+++ b/client/src/pages/Search/views/SearchPage.tsx
@@ -11,6 +11,8 @@ import {
   PRODUCT_FILTER_OPTIONS,
 } from '../../../common/constants';
 import { SearchPageContainer, SearchProductListWrapper } from '../style';
+import Loading from '../../../common/components/Loading';
+import ErrorPage from '../../../common/components/ErrorPage';
 const SearchPage = () => {
   const params = useParams();
   const [page, setPage] = useState(0);
@@ -33,6 +35,12 @@ const SearchPage = () => {
       console.log('err', err);
     }
   });
+  if (isLoading) {
+    return <Loading />;
+  }
+  if (error) {
+    return <ErrorPage />;
+  }
 
   return (
     <SearchPageContainer>


### PR DESCRIPTION
### 기능 요약
- search page 경로 추가
- 헤더의 검색 창에 검색어를 입력하고 엔터를 치면 검색한 내용이 아이템 카드의 제목과 내용에 일치하는 부분이 있으면 출력된다.
- 무한 스크롤은 추후 개발할 예정

### 화면/테스트 결과
![Jul-18-2023 02-26-04](https://github.com/codestates-seb/seb44_main_028/assets/72354092/2ac51be4-3c5b-48dd-af32-3f67bb92524a)


### 배운점
- onKeyDown 이벤트의 event 객체 타입은 `event: React.KeyboardEvent<HTMLInputElement>` 이다.