### PR TITLE
[FE] 회원탈퇴 401 에러 해결

### DIFF
--- a/client/src/pages/Create/components/WritePost.tsx
+++ b/client/src/pages/Create/components/WritePost.tsx
@@ -10,7 +10,7 @@ import { BsCheckLg } from 'react-icons/bs';
 import { BiErrorCircle } from 'react-icons/bi';
 import UploadImage from '../components/UploadImage';
 import ModalMain from '../../../common/components/Modal/ModalMain';
-import CheckBoxList from '../../../common/components/Checkbox/CheckBoxList';
+import CheckBoxList from '../../../common/components/CheckBox/CheckBoxList';
 import {
   CONTENT_DESCRIPTION,
   INPIT_VALIDATION,

--- a/client/src/pages/Login/views/LoginPage.tsx
+++ b/client/src/pages/Login/views/LoginPage.tsx
@@ -1,17 +1,27 @@
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 import KakaoLogin from '../components/KakaoLogin';
 import { LoginPageContainer } from '../style';
+import { ACCESS_TOKEN } from '../constants';
+import useDecryptToken from '../../../common/utils/customHooks/useDecryptToken';
 
 function LoginPage() {
+  const decrypt = useDecryptToken();
+  const encryptedAccessToken = localStorage.getItem(ACCESS_TOKEN);
+  if (!encryptedAccessToken) {
+    return null;
+  }
+  const accessToken = decrypt(encryptedAccessToken);
   const handleWithdrawal = () => {
     try {
-      console.log('회원탈퇴');
-      const response = axios.delete(
-        process.env.REACT_APP_API_URL + '/api/members/',
-      );
-      console.log(response);
-    } catch (error) {
-      console.log(error);
+      axios.delete(process.env.REACT_APP_API_URL + '/api/members', {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+    } catch (error: AxiosError | any) {
+      if (error.response.status === 401) {
+        alert('로그인이 만료되었습니다. 다시 로그인해주세요');
+      }
     }
   };
   return (

--- a/client/src/pages/Login/views/LoginPage.tsx
+++ b/client/src/pages/Login/views/LoginPage.tsx
@@ -1,8 +1,9 @@
+import { useNavigate } from 'react-router-dom';
 import axios, { AxiosError } from 'axios';
+import useDecryptToken from '../../../common/utils/customHooks/useDecryptToken';
 import KakaoLogin from '../components/KakaoLogin';
 import { LoginPageContainer } from '../style';
 import { ACCESS_TOKEN } from '../constants';
-import useDecryptToken from '../../../common/utils/customHooks/useDecryptToken';
 
 function LoginPage() {
   const decrypt = useDecryptToken();

--- a/client/src/pages/Login/views/LoginPage.tsx
+++ b/client/src/pages/Login/views/LoginPage.tsx
@@ -6,23 +6,28 @@ import { LoginPageContainer } from '../style';
 import { ACCESS_TOKEN } from '../constants';
 
 function LoginPage() {
+  const navigate = useNavigate();
   const decrypt = useDecryptToken();
   const encryptedAccessToken = localStorage.getItem(ACCESS_TOKEN);
   if (!encryptedAccessToken) {
+    navigate('/login');
     return null;
   }
   const accessToken = decrypt(encryptedAccessToken);
-  const handleWithdrawal = () => {
+  const handleWithdrawal = async () => {
     try {
-      axios.delete(process.env.REACT_APP_API_URL + '/api/members', {
+      await axios.delete(process.env.REACT_APP_API_URL + '/api/members', {
         headers: {
           Authorization: `Bearer ${accessToken}`,
         },
       });
+      localStorage.removeItem(ACCESS_TOKEN);
+      navigate('/');
     } catch (error: AxiosError | any) {
       if (error.response.status === 401) {
         alert('로그인이 만료되었습니다. 다시 로그인해주세요');
       }
+      navigate('/login');
     }
   };
   return (


### PR DESCRIPTION
### 기능 요약
- 헤더에 access token을 담는 로직 추가

### 화면/테스트 결과
![스크린샷 2023-07-18 오전 10 51 20](https://github.com/codestates-seb/seb44_main_028/assets/117507731/34e30a5f-480d-4797-a5b5-f8dc3ff17d92)

### 배운점
- 회원 탈퇴 시 헤더에 access token 담는 로직이 필요하다는 것을 알게 되었다.