### PR TITLE
[FE] 달력 시작 날짜 앞당겨 클릭하는 기능 추가/ 테스트 코드 작성 시작

### DIFF
--- a/client/src/PrivateRoutes.tsx
+++ b/client/src/PrivateRoutes.tsx
@@ -2,12 +2,21 @@ import { Navigate, Outlet } from 'react-router-dom';
 import { UseQueryResult } from 'react-query';
 import useGetMe from './common/utils/customHooks/useGetMe';
 import { IUserInfo } from './common/model/IUserInfo';
+import Loading from './common/components/Loading';
 
 function PrivateRoutes() {
-  // TODO: 로그인 여부를 getMe에서 가져오기
-  const { data: data }: UseQueryResult<IUserInfo | null> = useGetMe();
+  const { data, isLoading }: UseQueryResult<IUserInfo | null> = useGetMe();
 
-  // TODO: 로그인 여부에 따라서 라우팅 처리
-  return data ? <Outlet /> : <Navigate to="/login" />;
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  if (!data) {
+    // 로그인되지 않은 상태라면 로그인 페이지로 리디렉션
+    return <Navigate to="/login" />;
+  }
+
+  // 로그인된 상태라면 자식 라우트를 렌더링
+  return <Outlet />;
 }
 export default PrivateRoutes;

--- a/client/src/common/store/RootStore.tsx
+++ b/client/src/common/store/RootStore.tsx
@@ -6,7 +6,7 @@ import { interestProducts } from './InterestStore';
 import { monthlyReservation } from '../../pages/Booking/store/MonthlyReservationStore';
 import { mypageProfileSlice } from '../../pages/MyPage/store/ProfileSlice';
 
-const rootReducer = combineReducers({
+export const rootReducer = combineReducers({
   userInfo: userInfo.reducer,
   calendar: calendar.reducer,
   reservation: reservation.reducer,

--- a/client/src/common/utils/helperFunctions/__test__/makeCalendar.test.ts
+++ b/client/src/common/utils/helperFunctions/__test__/makeCalendar.test.ts
@@ -1,0 +1,12 @@
+import { makeCalendar } from '../makeCalendar';
+
+describe('makeCalendar', () => {
+  it('should generate a correct calendar for July 2023', () => {
+    const firstDayOfThisMonth = new Date(2023, 6, 1).getDay(); // July 2023 starts on Saturday
+    const lastDateOfThisMonth = new Date(2023, 7, 0).getDate(); // July 2023 has 31 days
+    const result = makeCalendar(firstDayOfThisMonth, lastDateOfThisMonth);
+
+    expect(result[0]).toEqual([0, 0, 0, 0, 0, 0, 1]); // July 2023 starts from Saturday
+    expect(result[5]).toEqual([30, 31, 0, 0, 0, 0, 0]); // July 2023 ends at 31
+  });
+});

--- a/client/src/pages/Booking/components/Dates.tsx
+++ b/client/src/pages/Booking/components/Dates.tsx
@@ -40,7 +40,17 @@ function Dates({ calendar, reservationDataFromServer }: CalendarProps) {
           day={j}
           reservationDataFromServer={reservationDataFromServer}
           onClick={() => {
-            if (!reservationDatesClickedByUser.startDate) {
+            if (
+              !reservationDatesClickedByUser.startDate ||
+              // startDate과 endDate 둘 다 있는데 유저가 원래 startDate보다 이전 날짜를 클릭했을 때
+              (reservationDatesClickedByUser.startDate &&
+                reservationDatesClickedByUser.endDate &&
+                new Date(
+                  reservationDatesClickedByUser.startDate.year,
+                  reservationDatesClickedByUser.startDate.month - 1,
+                  reservationDatesClickedByUser.startDate.date,
+                ).getTime() > new Date(year, month - 1, date).getTime())
+            ) {
               dispatch(
                 setStartDate({
                   ...reservationDatesClickedByUser,

--- a/client/src/pages/Booking/components/ReservationBtn.tsx
+++ b/client/src/pages/Booking/components/ReservationBtn.tsx
@@ -2,22 +2,33 @@ import { useMutation, useQueryClient } from 'react-query';
 import { useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import axios from 'axios';
+import useDecryptToken from '../../../common/utils/customHooks/useDecryptToken';
+import { makeDateFilledWithZero } from '../../../common/utils/helperFunctions/makeDateFilledWithZero';
 import BigBtn from '../../../common/components/Button';
 import { RootState } from '../../../common/store/RootStore';
 import { IReservationData } from '../model/IReservationData';
 import { colorPalette } from '../../../common/utils/enum/colorPalette';
+import { ACCESS_TOKEN } from '../../Login/constants';
 
 const sendReservationData = async ({
   startDate,
   endDate,
   productId,
+  accessToken,
 }: IReservationData) => {
+  console.log('startDate', startDate);
+  console.log('endDate', endDate);
   try {
     const response = await axios.post(
       `${process.env.REACT_APP_API_URL}/api/reservations/products/${productId}`,
       {
         startDate: startDate,
         endDate: endDate,
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
       },
     );
     console.log('1. POST 요청에 대한 응답', response);
@@ -29,6 +40,7 @@ const sendReservationData = async ({
 
 function ReservationBtn() {
   const { itemId } = useParams<{ itemId: string }>();
+  // 유저가 선택한 날짜를 가져온다.
   const currentReservationDate = useSelector(
     (state: RootState) => state.reservation,
   );
@@ -46,11 +58,27 @@ function ReservationBtn() {
     },
   });
 
+  const decrypt = useDecryptToken();
+  const encryptedAccessToken = localStorage.getItem(ACCESS_TOKEN);
+  if (!encryptedAccessToken) {
+    alert('로그인이 필요합니다.');
+    return null;
+  }
+  const accessToken = decrypt(encryptedAccessToken);
+
   const handleReservationClick = () => {
+    const startDate = currentReservationDate.startDate;
+    const endDate = currentReservationDate.endDate;
+    if (!startDate || !endDate) {
+      alert('날짜를 선택해주세요');
+      return null;
+    }
+
     mutation.mutate({
-      startDate: currentReservationDate.startDate,
-      endDate: currentReservationDate.endDate,
+      startDate: makeDateFilledWithZero(startDate),
+      endDate: makeDateFilledWithZero(endDate),
       productId: itemId,
+      accessToken,
     });
   };
 

--- a/client/src/pages/Booking/model/IReservationData.ts
+++ b/client/src/pages/Booking/model/IReservationData.ts
@@ -1,8 +1,7 @@
-import { DateType } from '../type';
-
 // 신규 예약 정보 POST 요청
 export interface IReservationData {
-  startDate: DateType | null;
-  endDate: DateType | null;
+  startDate: string | null;
+  endDate: string | null;
   productId: string | undefined;
+  accessToken: string | null;
 }

--- a/client/src/pages/Booking/tests/BookingDates.test.tsx
+++ b/client/src/pages/Booking/tests/BookingDates.test.tsx
@@ -7,7 +7,7 @@ import BookingDates from '../components/BookingDates';
 
 describe('BookingDates', () => {
   test('renders BookingDates component', () => {
-    // 가짜 store를 생성.
+    // store를 생성.
     const store = configureStore({
       reducer: rootReducer,
     });

--- a/client/src/pages/Booking/tests/BookingDates.test.tsx
+++ b/client/src/pages/Booking/tests/BookingDates.test.tsx
@@ -1,0 +1,24 @@
+import '@testing-library/jest-dom/extend-expect';
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { rootReducer } from '../../../common/store/RootStore';
+import BookingDates from '../components/BookingDates';
+
+describe('BookingDates', () => {
+  test('renders BookingDates component', () => {
+    // 가짜 store를 생성.
+    const store = configureStore({
+      reducer: rootReducer,
+    });
+
+    render(
+      <Provider store={store}>
+        <BookingDates />
+      </Provider>,
+    );
+
+    expect(screen.getByText(/예약 시작 날짜/i)).toBeInTheDocument();
+    expect(screen.getByText(/예약 마감 날짜/i)).toBeInTheDocument();
+  });
+});

--- a/client/src/pages/Booking/tests/Calendars.test.tsx
+++ b/client/src/pages/Booking/tests/Calendars.test.tsx
@@ -1,0 +1,55 @@
+import '@testing-library/jest-dom/extend-expect';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { rootReducer } from '../../../common/store/RootStore';
+import Calendars from '../components/Calendars';
+import { clearReservationDates } from '../store/ReservationDateStore';
+
+describe('Calendars', () => {
+  test('renders Calendars component', () => {
+    // store를 생성.
+    const store = configureStore({
+      reducer: rootReducer,
+    });
+
+    render(
+      <Provider store={store}>
+        <Calendars />
+      </Provider>,
+    );
+
+    //TODO: MonthSwitchBtns 컴포넌트의 존재 여부를 확인.
+
+    // TODO: Calendar 컴포넌트의 존재 여부를 확인.
+
+    // "시작 날짜 재설정" 버튼의 존재 여부를 확인합니다.
+    expect(
+      screen.getByRole('button', { name: /시작 날짜 재설정/i }),
+    ).toBeInTheDocument();
+  });
+
+  test('handles clear reservation button click', () => {
+    // store를 생성합니다.
+    const store = configureStore({
+      reducer: rootReducer,
+    });
+
+    render(
+      <Provider store={store}>
+        <Calendars />
+      </Provider>,
+    );
+
+    // "시작 날짜 재설정" 버튼을 클릭합니다.
+    fireEvent.click(screen.getByRole('button', { name: /시작 날짜 재설정/i }));
+
+    // clearReservationDates 액션이 dispatch되었는지 확인합니다.
+    store.dispatch(clearReservationDates());
+
+    // 액션이 디스패치되었거나 상태가 업데이트되었는지 확인
+    const state = store.getState();
+    expect(state.reservation.startDate).toEqual(null);
+    expect(state.reservation.endDate).toEqual(null);
+  });
+});

--- a/client/src/pages/Booking/tests/Days.test.tsx
+++ b/client/src/pages/Booking/tests/Days.test.tsx
@@ -1,0 +1,17 @@
+import '@testing-library/jest-dom/extend-expect';
+import { render, screen } from '@testing-library/react';
+import Days from '../components/Days';
+
+describe('Days', () => {
+  test('renders days of the week', () => {
+    render(<Days />);
+
+    const dayElements = screen.getAllByRole('columnheader');
+    const daysOfWeek = ['일', '월', '화', '수', '목', '금', '토'];
+
+    expect(dayElements).toHaveLength(7);
+    dayElements.forEach((dayElement, index) => {
+      expect(dayElement).toHaveTextContent(daysOfWeek[index]);
+    });
+  });
+});

--- a/client/src/pages/Create/components/WritePost.tsx
+++ b/client/src/pages/Create/components/WritePost.tsx
@@ -10,7 +10,7 @@ import { BsCheckLg } from 'react-icons/bs';
 import { BiErrorCircle } from 'react-icons/bi';
 import UploadImage from '../components/UploadImage';
 import ModalMain from '../../../common/components/Modal/ModalMain';
-import CheckBoxList from '../../../common/components/Checkbox/CheckBoxList';
+import CheckBoxList from '../../../common/components/CheckBox/CheckBoxList';
 import {
   CONTENT_DESCRIPTION,
   INPIT_VALIDATION,


### PR DESCRIPTION
### 기능 요약
[달력에서 예약 날짜 클릭 시 시작 날짜를 기존보다 앞당겨 클릭하는 기능 추가]
[테스트코드 작성 시작]
- 유닛 테스트: 달력을 만들어주는 함수의 반환값이 의도한 결과와 같은지를 테스트하는 코드 추가
- 통합 테스트: 함수형 컴포넌트 렌더링 테스트 코드 추가

### 화면/테스트 결과
[달력 시작 날짜 앞당겨 클릭하는 기능]
![화면-기록-2023-07-19-오전-8 09 28](https://github.com/codestates-seb/seb44_main_028/assets/117507731/fda23436-f590-4012-87af-227948791607)

[테스트 코드 작성 결과]
- 함수형 컴포넌트는 아직 렌더링이 잘 되는지 정도만 테스트 코드를 작성해놓은 상태여서 통과가 잘 되었다.
- makeCalendar 함수도 아직 2023년 7월 달력만 의도한 바와 같은지 테스트 코드를 작성했기 때문에 통과를 했고, 향후 3년치 달력 테스트 코드를 추가 예정이다.

### 배운점
- 테스트 코드 작성 시 헬퍼함수 단위로 유닛 테스트를 진행하는 것이 좋을 것 같다. 리팩토링을 더 해보면서 헬퍼함수로 분리할 수 있는 것은 분리하여 테스트 코드를 작성해나가야겠다.