### PR TITLE
[FE] 달력 코드 중 복잡한 로직의 경우 helper function과 custom hook으로 분리

### DIFF
--- a/client/src/common/utils/customHooks/useGetReservationData.tsx
+++ b/client/src/common/utils/customHooks/useGetReservationData.tsx
@@ -1,0 +1,32 @@
+import axios from 'axios';
+import { turnStringArrIntoDateObjectArr } from '../helperFunctions/turnStringArrIntoDateObjectArr';
+
+const useGetReservationData = (itemId: string | undefined) => {
+  const getReservationData = async () => {
+    const today = new Date();
+    const year = today.getFullYear();
+    const currentMonth = (today.getMonth() + 1).toString().padStart(2, '0');
+    const nextMonth = (today.getMonth() + 2).toString().padStart(2, '0');
+
+    const res = await axios.get(
+      process.env.REACT_APP_API_URL +
+        `/api/reservations/products/${itemId}/calendar?date1=${year}-${currentMonth}&date2=${year}-${nextMonth}`,
+    );
+
+    const data = {
+      productTitle: res.data.productTitle,
+      baseFee: res.data.baseFee,
+      feePerDay: res.data.feePerDay,
+      minimumRentalPeriod: res.data.minimumRentalPeriod,
+      reservationsDate1: turnStringArrIntoDateObjectArr(
+        res.data.reservationsDate1,
+      ),
+      reservationsDate2: turnStringArrIntoDateObjectArr(
+        res.data.reservationsDate2,
+      ),
+    };
+    return data;
+  };
+  return getReservationData;
+};
+export default useGetReservationData;

--- a/client/src/common/utils/customHooks/usePostReservationData.tsx
+++ b/client/src/common/utils/customHooks/usePostReservationData.tsx
@@ -1,0 +1,33 @@
+import axios, { AxiosError } from 'axios';
+import { IReservationData } from '../../../pages/Booking/model/IReservationData';
+
+const usePostReservationData = () => {
+  const sendReservationData = async ({
+    startDate,
+    endDate,
+    productId,
+    accessToken,
+  }: IReservationData) => {
+    try {
+      const response = await axios.post(
+        `${process.env.REACT_APP_API_URL}/api/reservations/products/${productId}`,
+        {
+          startDate: startDate,
+          endDate: endDate,
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        },
+      );
+      alert('예약이 완료되었습니다.');
+
+      return response.data;
+    } catch (error: AxiosError | any) {
+      console.log('POST 요청 시 에러', error.message);
+    }
+  };
+  return sendReservationData;
+};
+export default usePostReservationData;

--- a/client/src/common/utils/helperFunctions/calculateDateDifference.ts
+++ b/client/src/common/utils/helperFunctions/calculateDateDifference.ts
@@ -1,0 +1,19 @@
+import { DateType } from '../../../pages/Booking/type';
+
+export function calculateDateDifference(
+  startDate: DateType,
+  endDate: DateType,
+) {
+  // JavaScript의 Date 객체의 month 인자는 0부터 시작합니다.
+  // 따라서, month에서 1을 빼줍니다.
+  const start = new Date(startDate.year, startDate.month - 1, startDate.date);
+  const end = new Date(endDate.year, endDate.month - 1, endDate.date);
+
+  // 두 날짜 사이의 차이는 밀리초 단위이므로, 이를 일 단위로 바꾸기 위해
+  // 1000(밀리초->초), 60(초->분), 60(분->시간), 24(시간->일)로 나눕니다.
+  const differenceInDays = Math.round(
+    (end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24),
+  );
+
+  return differenceInDays + 1;
+}

--- a/client/src/common/utils/helperFunctions/convertStringToDateObject.ts
+++ b/client/src/common/utils/helperFunctions/convertStringToDateObject.ts
@@ -1,0 +1,8 @@
+export const convertStringToDateObject = (dateStr: string) => {
+  const dateParts = dateStr.split('-');
+  return {
+    year: parseInt(dateParts[0], 10),
+    month: parseInt(dateParts[1], 10),
+    date: parseInt(dateParts[2], 10),
+  };
+};

--- a/client/src/common/utils/helperFunctions/decryptToken.ts
+++ b/client/src/common/utils/helperFunctions/decryptToken.ts
@@ -1,0 +1,9 @@
+import CryptoJS from 'crypto-js';
+
+export const decryptToken = (encryptedToken: string) => {
+  const bytes = CryptoJS.AES.decrypt(
+    encryptedToken,
+    process.env.REACT_APP_SECRET_KEY as string,
+  );
+  return bytes.toString(CryptoJS.enc.Utf8);
+};

--- a/client/src/common/utils/helperFunctions/encryptToken.ts
+++ b/client/src/common/utils/helperFunctions/encryptToken.ts
@@ -1,0 +1,8 @@
+import CryptoJS from 'crypto-js';
+
+export const encryptToken = (token: string) => {
+  return CryptoJS.AES.encrypt(
+    token,
+    process.env.REACT_APP_SECRET_KEY as string,
+  ).toString();
+};

--- a/client/src/common/utils/helperFunctions/isWithinPeriod.ts
+++ b/client/src/common/utils/helperFunctions/isWithinPeriod.ts
@@ -1,0 +1,32 @@
+import { StartEndDateProps } from '../../../pages/Booking/model/IStartEndDateProps';
+import { DateType } from '../../../pages/Booking/type';
+
+export const isWithinPeriod = (
+  startDate: DateType,
+  endDate: DateType,
+  reservation: StartEndDateProps,
+) => {
+  const start = new Date(startDate.year, startDate.month - 1, startDate.date);
+  const end = new Date(endDate.year, endDate.month - 1, endDate.date);
+
+  const reservationStart = new Date(
+    reservation.startDate.year,
+    reservation.startDate.month - 1,
+    reservation.startDate.date,
+  );
+  const reservationEnd = new Date(
+    reservation.endDate.year,
+    reservation.endDate.month - 1,
+    reservation.endDate.date,
+  );
+
+  // 시작 날짜와 종료 날짜가 예약 기간 안에 있는지 확인
+  if (start >= reservationStart && start <= reservationEnd) return true;
+  if (end >= reservationStart && end <= reservationEnd) return true;
+
+  // 예약이 시작 날짜와 종료 날짜 사이에 있는지 확인
+  if (reservationStart >= start && reservationStart <= end) return true;
+  if (reservationEnd >= start && reservationEnd <= end) return true;
+
+  return false;
+};

--- a/client/src/common/utils/helperFunctions/turnStringArrIntoDateObjectArr.ts
+++ b/client/src/common/utils/helperFunctions/turnStringArrIntoDateObjectArr.ts
@@ -1,19 +1,14 @@
+import { convertStringToDateObject } from './convertStringToDateObject';
+
 export const turnStringArrIntoDateObjectArr = (
   date: { startDate: string; endDate: string }[],
 ) => {
   const dateObjectArr = date.map(
     (dateObj: { startDate: string; endDate: string }) => {
-      const startDate = {
-        year: Number(dateObj.startDate.slice(0, 4)),
-        month: Number(dateObj.startDate.slice(5, 7)),
-        date: Number(dateObj.startDate.slice(8, 10)),
+      return {
+        startDate: convertStringToDateObject(dateObj.startDate),
+        endDate: convertStringToDateObject(dateObj.endDate),
       };
-      const endDate = {
-        year: Number(dateObj.endDate.slice(0, 4)),
-        month: Number(dateObj.endDate.slice(5, 7)),
-        date: Number(dateObj.endDate.slice(8, 10)),
-      };
-      return { startDate, endDate };
     },
   );
   return dateObjectArr;

--- a/client/src/pages/Booking/components/BookingDates.tsx
+++ b/client/src/pages/Booking/components/BookingDates.tsx
@@ -1,8 +1,10 @@
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { BookingDatesForm, SeparationLine } from '../style';
 import { makeDateFilledWithZero } from '../../../common/utils/helperFunctions/makeDateFilledWithZero';
 import { RootState } from '../../../common/store/RootStore';
 import DatesUserClickd from './DatesUserClicked';
+import { clearReservationDates } from '../store/ReservationDateStore';
+import Separation from './Refresh';
 
 function BookingDates() {
   const reservationStartDate = useSelector(
@@ -20,11 +22,13 @@ function BookingDates() {
   const endDateFilledWithZero = makeDateFilledWithZero(reservationEndDate, '.');
 
   return (
-    <BookingDatesForm>
-      <DatesUserClickd text="예약 시작 날짜" date={startDateFilledWithZero} />
-      <SeparationLine>|</SeparationLine>
-      <DatesUserClickd text="예약 마감 날짜" date={endDateFilledWithZero} />
-    </BookingDatesForm>
+    <>
+      <BookingDatesForm>
+        <DatesUserClickd text="예약 시작 날짜" date={startDateFilledWithZero} />
+        <SeparationLine>|</SeparationLine>
+        <DatesUserClickd text="예약 마감 날짜" date={endDateFilledWithZero} />
+      </BookingDatesForm>
+    </>
   );
 }
 export default BookingDates;

--- a/client/src/pages/Booking/components/BookingDates.tsx
+++ b/client/src/pages/Booking/components/BookingDates.tsx
@@ -1,13 +1,8 @@
 import { useSelector } from 'react-redux';
-import {
-  BookingDatesForm,
-  BookingDatesLabel,
-  DatesWrapper,
-  ReservationDate,
-  SeparationLine,
-} from '../style';
+import { BookingDatesForm, SeparationLine } from '../style';
 import { makeDateFilledWithZero } from '../../../common/utils/helperFunctions/makeDateFilledWithZero';
 import { RootState } from '../../../common/store/RootStore';
+import DatesUserClickd from './DatesUserClicked';
 
 function BookingDates() {
   const reservationStartDate = useSelector(
@@ -26,15 +21,9 @@ function BookingDates() {
 
   return (
     <BookingDatesForm>
-      <DatesWrapper>
-        <BookingDatesLabel>예약 시작 날짜</BookingDatesLabel>
-        <ReservationDate>{startDateFilledWithZero}</ReservationDate>
-      </DatesWrapper>
+      <DatesUserClickd text="예약 시작 날짜" date={startDateFilledWithZero} />
       <SeparationLine>|</SeparationLine>
-      <DatesWrapper>
-        <BookingDatesLabel>예약 마감 날짜</BookingDatesLabel>
-        <ReservationDate>{endDateFilledWithZero}</ReservationDate>
-      </DatesWrapper>
+      <DatesUserClickd text="예약 마감 날짜" date={endDateFilledWithZero} />
     </BookingDatesForm>
   );
 }

--- a/client/src/pages/Booking/components/Calendars.tsx
+++ b/client/src/pages/Booking/components/Calendars.tsx
@@ -1,12 +1,10 @@
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import Calendar from './Calendar';
 import MonthSwitchBtns from './MonthSwitchBtns';
-import { clearReservationDates } from '../store/ReservationDateStore';
 import { CalendarContainer, CalendarWrapper } from '../style';
 import { RootState } from '../../../common/store/RootStore';
 
 function Calendars() {
-  const dispatch = useDispatch();
   const current = useSelector((state: RootState) => state.calendar);
   const next =
     current.month === 12
@@ -19,10 +17,6 @@ function Calendars() {
   const reservationData2 = useSelector(
     (state: RootState) => state.monthlyReservation.reservationsDate2,
   );
-
-  const handleClearReservation = () => {
-    dispatch(clearReservationDates());
-  };
 
   return (
     <CalendarContainer>

--- a/client/src/pages/Booking/components/DatesUserClicked.tsx
+++ b/client/src/pages/Booking/components/DatesUserClicked.tsx
@@ -1,0 +1,16 @@
+import { BookingDatesLabel, DatesWrapper, ReservationDate } from '../style';
+
+type DatesUserClickdProps = {
+  text: string;
+  date: string | null;
+};
+
+function DatesUserClickd({ text, date }: DatesUserClickdProps) {
+  return (
+    <DatesWrapper>
+      <BookingDatesLabel>{text}</BookingDatesLabel>
+      <ReservationDate>{date}</ReservationDate>
+    </DatesWrapper>
+  );
+}
+export default DatesUserClickd;

--- a/client/src/pages/Booking/components/Refresh.tsx
+++ b/client/src/pages/Booking/components/Refresh.tsx
@@ -1,0 +1,15 @@
+import { useDispatch } from 'react-redux';
+import { clearReservationDates } from '../store/ReservationDateStore';
+import { RefreshBtn } from '../style';
+
+function Refresh() {
+  const dispatch = useDispatch();
+  const handleClearReservation = (
+    event: React.MouseEvent<HTMLButtonElement>,
+  ) => {
+    event.preventDefault();
+    dispatch(clearReservationDates());
+  };
+  return <RefreshBtn onClick={handleClearReservation}>날짜 재설정</RefreshBtn>;
+}
+export default Refresh;

--- a/client/src/pages/Booking/components/RentalProductInfo.tsx
+++ b/client/src/pages/Booking/components/RentalProductInfo.tsx
@@ -1,5 +1,5 @@
-import { ProductInfo, ProductInfoTitle, ProductInfoWrapper } from '../style';
 import { useSelector } from 'react-redux';
+import { ProductInfo, ProductInfoTitle, ProductInfoWrapper } from '../style';
 import { RootState } from '../../../common/store/RootStore';
 
 function RentalProductInfo() {

--- a/client/src/pages/Booking/components/RentalProductInfo.tsx
+++ b/client/src/pages/Booking/components/RentalProductInfo.tsx
@@ -1,6 +1,12 @@
 import { ProductInfo, ProductInfoTitle, ProductInfoWrapper } from '../style';
+import { useSelector } from 'react-redux';
+import { RootState } from '../../../common/store/RootStore';
 
-function RentalProductInfo({ monthlyReservation }: any) {
+function RentalProductInfo() {
+  const monthlyReservation = useSelector(
+    (state: RootState) => state.monthlyReservation,
+  );
+
   return (
     <>
       <ProductInfoTitle>

--- a/client/src/pages/Booking/components/RentalProductInfo.tsx
+++ b/client/src/pages/Booking/components/RentalProductInfo.tsx
@@ -1,0 +1,19 @@
+import { ProductInfo, ProductInfoTitle, ProductInfoWrapper } from '../style';
+
+function RentalProductInfo({ monthlyReservation }: any) {
+  return (
+    <>
+      <ProductInfoTitle>
+        렌탈 품목 : {monthlyReservation.productTitle}
+      </ProductInfoTitle>
+      <ProductInfoWrapper>
+        <ProductInfo>기본료 : {monthlyReservation.baseFee}원</ProductInfo>
+        <ProductInfo>1일 사용료 : {monthlyReservation.feePerDay}원</ProductInfo>
+        <ProductInfo>
+          최소 예약 기간 : {monthlyReservation.minimumRentalPeriod}일
+        </ProductInfo>
+      </ProductInfoWrapper>
+    </>
+  );
+}
+export default RentalProductInfo;

--- a/client/src/pages/Booking/components/ReservationBtn.tsx
+++ b/client/src/pages/Booking/components/ReservationBtn.tsx
@@ -95,11 +95,7 @@ function ReservationBtn({
 
   const decrypt = useDecryptToken();
   const encryptedAccessToken = localStorage.getItem(ACCESS_TOKEN);
-  if (!encryptedAccessToken) {
-    // navigate('/login');
-    return null;
-  }
-  const accessToken = decrypt(encryptedAccessToken);
+  const accessToken = decrypt(encryptedAccessToken || '');
 
   console.log('startDate', currentReservationDate.startDate);
   console.log('endDate', currentReservationDate.endDate);

--- a/client/src/pages/Booking/components/ReservationBtn.tsx
+++ b/client/src/pages/Booking/components/ReservationBtn.tsx
@@ -1,91 +1,34 @@
 import { useMutation, useQueryClient } from 'react-query';
 import { useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
-import axios, { AxiosError } from 'axios';
-import useDecryptToken from '../../../common/utils/customHooks/useDecryptToken';
+import { AxiosError } from 'axios';
 import { makeDateFilledWithZero } from '../../../common/utils/helperFunctions/makeDateFilledWithZero';
 import BigBtn from '../../../common/components/Button';
 import { RootState } from '../../../common/store/RootStore';
-import { IReservationData } from '../model/IReservationData';
 import { colorPalette } from '../../../common/utils/enum/colorPalette';
 import { ACCESS_TOKEN } from '../../Login/constants';
-import { DateType } from '../type';
-import useGetMe from '../../../common/utils/customHooks/useGetMe';
+import { calculateDateDifference } from '../../../common/utils/helperFunctions/calculateDateDifference';
+import usePostReservationData from '../../../common/utils/customHooks/usePostReservationData';
+import { decryptToken } from '../../../common/utils/helperFunctions/decryptToken';
 
-const sendReservationData = async ({
-  startDate,
-  endDate,
-  productId,
-  accessToken,
-}: IReservationData) => {
-  console.log('startDate', startDate);
-  console.log('endDate', endDate);
-  try {
-    const response = await axios.post(
-      `${process.env.REACT_APP_API_URL}/api/reservations/products/${productId}`,
-      {
-        startDate: startDate,
-        endDate: endDate,
-      },
-      {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      },
-    );
-    console.log('1. POST 요청에 대한 응답', response);
-    alert('예약이 완료되었습니다.');
-
-    return response.data;
-  } catch (error: AxiosError | any) {
-    console.log('POST 요청 시 에러', error.message);
-  }
+type ReservationBtnProps = {
+  minimumRentalPeriod: number;
 };
 
-function calculateDateDifference(startDate: DateType, endDate: DateType) {
-  // JavaScript의 Date 객체의 month 인자는 0부터 시작합니다.
-  // 따라서, month에서 1을 빼줍니다.
-  const start = new Date(startDate.year, startDate.month - 1, startDate.date);
-  const end = new Date(endDate.year, endDate.month - 1, endDate.date);
-
-  // 두 날짜 사이의 차이는 밀리초 단위이므로, 이를 일 단위로 바꾸기 위해
-  // 1000(밀리초->초), 60(초->분), 60(분->시간), 24(시간->일)로 나눕니다.
-  const differenceInDays = Math.round(
-    (end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24),
-  );
-
-  return differenceInDays + 1;
-}
-
-function ReservationBtn({
-  minimumRentalPeriod,
-}: {
-  minimumRentalPeriod: number;
-}) {
+function ReservationBtn({ minimumRentalPeriod }: ReservationBtnProps) {
   const { itemId } = useParams<{ itemId: string }>();
   // 유저가 선택한 날짜를 가져온다.
   const currentReservationDate = useSelector(
     (state: RootState) => state.reservation,
   );
   const navigate = useNavigate();
-  console.log('시작 날짜', currentReservationDate.startDate);
-  console.log('마감 날짜', currentReservationDate.endDate);
-  if (currentReservationDate.startDate && currentReservationDate.endDate) {
-    console.log(
-      '두 날짜의 차이',
-      calculateDateDifference(
-        currentReservationDate.startDate,
-        currentReservationDate.endDate,
-      ),
-    );
-  }
 
   const queryClient = useQueryClient();
+  const sendReservationData = usePostReservationData();
 
   const mutation = useMutation(sendReservationData, {
     onSuccess: () => {
       queryClient.invalidateQueries('reservation');
-      console.log('예약 성공');
       navigate('/mypage');
     },
     onError: (error: AxiosError) => {
@@ -93,42 +36,22 @@ function ReservationBtn({
     },
   });
 
-  const decrypt = useDecryptToken();
   const encryptedAccessToken = localStorage.getItem(ACCESS_TOKEN);
-  const accessToken = decrypt(encryptedAccessToken || '');
-
-  console.log('startDate', currentReservationDate.startDate);
-  console.log('endDate', currentReservationDate.endDate);
-
-  const { data: userData, isError } = useGetMe();
+  const accessToken = decryptToken(encryptedAccessToken || '');
+  console.log('accessToken', accessToken);
 
   const handleReservationClick = () => {
     const startDate = currentReservationDate.startDate;
     const endDate = currentReservationDate.endDate;
 
-    if (isError) {
-      alert('로그인 후 이용해주세요.');
-      return null;
-    }
-
-    if (
-      currentReservationDate.startDate &&
-      currentReservationDate.endDate &&
-      calculateDateDifference(
-        currentReservationDate.startDate,
-        currentReservationDate.endDate,
-      ) &&
-      calculateDateDifference(
-        currentReservationDate.startDate,
-        currentReservationDate.endDate,
-      ) < minimumRentalPeriod
-    ) {
-      alert('최소 대여 기간보다 짧게 예약할 수 없습니다.');
-      return null;
-    }
     if (!startDate || !endDate) {
       alert('날짜를 선택해주세요');
-      return null;
+      return;
+    }
+
+    if (calculateDateDifference(startDate, endDate) < minimumRentalPeriod) {
+      alert('최소 대여 기간보다 짧게 예약할 수 없습니다.');
+      return;
     }
 
     mutation.mutate({

--- a/client/src/pages/Booking/store/MonthlyReservationStore.tsx
+++ b/client/src/pages/Booking/store/MonthlyReservationStore.tsx
@@ -19,7 +19,6 @@ export const monthlyReservation = createSlice({
       state,
       action: PayloadAction<IMonthlyReservation>,
     ) => {
-      console.log('예약 정보', action.payload);
       state.productTitle = action.payload.productTitle;
       state.baseFee = action.payload.baseFee;
       state.feePerDay = action.payload.feePerDay;

--- a/client/src/pages/Booking/store/ReservationDateStore.tsx
+++ b/client/src/pages/Booking/store/ReservationDateStore.tsx
@@ -1,36 +1,7 @@
 import { configureStore, createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { StartEndDateProps } from '../model/IStartEndDateProps';
 import { DateType } from '../type';
-
-function isWithinPeriod(
-  startDate: DateType,
-  endDate: DateType,
-  reservation: StartEndDateProps,
-) {
-  const start = new Date(startDate.year, startDate.month - 1, startDate.date);
-  const end = new Date(endDate.year, endDate.month - 1, endDate.date);
-
-  const reservationStart = new Date(
-    reservation.startDate.year,
-    reservation.startDate.month - 1,
-    reservation.startDate.date,
-  );
-  const reservationEnd = new Date(
-    reservation.endDate.year,
-    reservation.endDate.month - 1,
-    reservation.endDate.date,
-  );
-
-  // 시작 날짜와 종료 날짜가 예약 기간 안에 있는지 확인
-  if (start >= reservationStart && start <= reservationEnd) return true;
-  if (end >= reservationStart && end <= reservationEnd) return true;
-
-  // 예약이 시작 날짜와 종료 날짜 사이에 있는지 확인
-  if (reservationStart >= start && reservationStart <= end) return true;
-  if (reservationEnd >= start && reservationEnd <= end) return true;
-
-  return false;
-}
+import { isWithinPeriod } from '../../../common/utils/helperFunctions/isWithinPeriod';
 
 type ReservationProps = {
   startDate: DateType | null;
@@ -62,7 +33,6 @@ export const reservation = createSlice({
       const todaysDate = today.getDate();
 
       const allReservations = action.payload.allReservations;
-      console.log('allReservations', allReservations);
 
       for (const reservation of allReservations) {
         if (
@@ -77,11 +47,8 @@ export const reservation = createSlice({
       }
 
       if (
-        newStartYear > todaysYear ||
-        (newStartYear === todaysYear && newStartMonth > todaysMonth) ||
-        (newStartYear === todaysYear &&
-          newStartMonth === todaysMonth &&
-          newStartDate >= todaysDate)
+        new Date(newStartYear, newStartMonth - 1, newStartDate) >=
+        new Date(todaysYear, todaysMonth - 1, todaysDate)
       ) {
         state.startDate = newStart;
       }
@@ -112,11 +79,8 @@ export const reservation = createSlice({
       }
 
       if (
-        currentStartYear < newEndYear ||
-        (currentStartYear === newEndYear && currentStartMonth < newEndMonth) ||
-        (currentStartYear === newEndYear &&
-          currentStartMonth === newEndMonth &&
-          currentStartDate <= newEndDate)
+        new Date(currentStartYear, currentStartMonth - 1, currentStartDate) <=
+        new Date(newEndYear, newEndMonth - 1, newEndDate)
       ) {
         state.endDate = newEnd;
       }

--- a/client/src/pages/Booking/style.ts
+++ b/client/src/pages/Booking/style.ts
@@ -304,3 +304,25 @@ export const SeparationLine = styled.span`
   font-weight: 300;
   color: rgba(0, 0, 0, 0.1);
 `;
+
+export const ProductInfoWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: flex-start;
+  border: none;
+  border-radius: 15px;
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.5);
+`;
+
+export const ProductInfoTitle = styled.p`
+  margin: 0 0 20px 0;
+  padding: 10px;
+  font-size: 18px;
+`;
+
+export const ProductInfo = styled.p`
+  margin: 10px;
+  padding: 10px;
+  font-size: 15px;
+`;

--- a/client/src/pages/Booking/style.ts
+++ b/client/src/pages/Booking/style.ts
@@ -18,6 +18,7 @@ export const CalendarContainer = styled.div`
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
+  margin-top: 0;
   width: 807px;
 `;
 
@@ -300,9 +301,10 @@ export const EachDate = styled.th<EachDatesProps>`
 
 export const SeparationLine = styled.span`
   position: absolute;
-  font-size: 70px;
-  font-weight: 300;
+  font-size: 60px;
+  font-weight: 100;
   color: rgba(0, 0, 0, 0.1);
+  border: none;
 `;
 
 export const ProductInfoWrapper = styled.div`
@@ -325,4 +327,14 @@ export const ProductInfo = styled.p`
   margin: 10px;
   padding: 10px;
   font-size: 15px;
+`;
+
+export const RefreshBtn = styled.button`
+  margin: 10px 0 -20px;
+  height: 40px;
+  width: 400px;
+  background-size: cover;
+  background-color: white;
+  border: rgba(0, 0, 0, 0.1) 1px solid;
+  cursor: pointer;
 `;

--- a/client/src/pages/Booking/views/BookingPage.tsx
+++ b/client/src/pages/Booking/views/BookingPage.tsx
@@ -14,7 +14,6 @@ import RentalProductInfo from '../components/RentalProductInfo';
 import useGetReservationData from '../../../common/utils/customHooks/useGetReservationData';
 
 function BookingPage() {
-  // GET요청으로 기존 예약 정보 가져오기
   const dispatch = useDispatch();
   const { itemId } = useParams<{ itemId: string }>();
 

--- a/client/src/pages/Booking/views/BookingPage.tsx
+++ b/client/src/pages/Booking/views/BookingPage.tsx
@@ -12,6 +12,7 @@ import useScrollToTop from '../../../common/utils/customHooks/useScrollToTop';
 import { clearReservationDates } from '../store/ReservationDateStore';
 import RentalProductInfo from '../components/RentalProductInfo';
 import useGetReservationData from '../../../common/utils/customHooks/useGetReservationData';
+import Refresh from '../components/Refresh';
 
 function BookingPage() {
   const dispatch = useDispatch();
@@ -21,6 +22,7 @@ function BookingPage() {
 
   const location = useLocation();
   useEffect(() => {
+    // window.location.reload();
     return () => {
       dispatch(clearReservationDates());
     };
@@ -46,18 +48,17 @@ function BookingPage() {
     }
   }, [isLoading, data, dispatch]);
 
-  const monthlyReservation = useSelector(
-    (state: RootState) => state.monthlyReservation,
+  const minimumRentalPeriod = useSelector(
+    (state: RootState) => state.monthlyReservation.minimumRentalPeriod,
   );
 
   return (
     <BookingPageContainer>
       <BookingDates />
+      <Refresh />
       <Calendars />
-      <RentalProductInfo monthlyReservation={monthlyReservation} />
-      <ReservationBtn
-        minimumRentalPeriod={monthlyReservation.minimumRentalPeriod}
-      />
+      <RentalProductInfo />
+      <ReservationBtn minimumRentalPeriod={minimumRentalPeriod} />
     </BookingPageContainer>
   );
 }

--- a/client/src/pages/Booking/views/BookingPage.tsx
+++ b/client/src/pages/Booking/views/BookingPage.tsx
@@ -1,61 +1,22 @@
-import axios from 'axios';
+import { useEffect } from 'react';
+import { useQuery } from 'react-query';
+import { useLocation, useParams } from 'react-router-dom';
 import BookingDates from '../components/BookingDates';
 import Calendars from '../components/Calendars';
 import ReservationBtn from '../components/ReservationBtn';
-import { BookingPageContainer } from '../style';
-import { useLocation, useParams } from 'react-router-dom';
-import { useEffect, useState } from 'react';
-import { StartEndDateProps } from '../model/IStartEndDateProps';
 import { useDispatch, useSelector } from 'react-redux';
+import { BookingPageContainer } from '../style';
 import { setMonthlyReservation } from '../store/MonthlyReservationStore';
 import { RootState } from '../../../common/store/RootStore';
 import useScrollToTop from '../../../common/utils/customHooks/useScrollToTop';
 import { clearReservationDates } from '../store/ReservationDateStore';
-import styled from 'styled-components';
-
-export const ProductInfoWrapper = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-start;
-  align-items: flex-start;
-  border: none;
-  border-radius: 15px;
-  box-shadow: 0 0 5px rgba(0, 0, 0, 0.5);
-`;
-
-export const ProductInfoTitle = styled.p`
-  margin: 0 0 20px 0;
-  padding: 10px;
-  font-size: 18px;
-`;
-
-export const ProductInfo = styled.p`
-  margin: 10px;
-  padding: 10px;
-  font-size: 15px;
-`;
-
-const convertStringToDateObject = (dateStr: string) => {
-  const dateParts = dateStr.split('-');
-  return {
-    year: parseInt(dateParts[0], 10),
-    month: parseInt(dateParts[1], 10),
-    date: parseInt(dateParts[2], 10),
-  };
-};
-
-const convertReservationDates = (reservations: any) => {
-  return reservations.map((reservation: any) => {
-    return {
-      startDate: convertStringToDateObject(reservation.startDate),
-      endDate: convertStringToDateObject(reservation.endDate),
-    };
-  });
-};
+import RentalProductInfo from '../components/RentalProductInfo';
+import useGetReservationData from '../../../common/utils/customHooks/useGetReservationData';
 
 function BookingPage() {
   // GET요청으로 기존 예약 정보 가져오기
   const dispatch = useDispatch();
+  const { itemId } = useParams<{ itemId: string }>();
 
   useScrollToTop();
 
@@ -66,72 +27,35 @@ function BookingPage() {
     };
   }, [location]);
 
-  interface IMonthlyReservation {
-    productTitle: string;
-    baseFee: number;
-    feePerDay: number;
-    minimumRentalPeriod: number;
-    reservationsDate1: StartEndDateProps[];
-    reservationsDate2: StartEndDateProps[];
-  }
-  const today = new Date();
-  const year = today.getFullYear();
-  const currentMonth = (today.getMonth() + 1).toString().padStart(2, '0');
-  const nextMonth = (today.getMonth() + 2).toString().padStart(2, '0');
+  const getReservationData = useGetReservationData(itemId);
 
-  const { itemId } = useParams<{ itemId: string }>();
+  const { isLoading, isError, error, data } = useQuery(
+    ['reservation', itemId],
+    () => getReservationData(),
+    {
+      enabled: !!itemId,
+    },
+  );
+
   useEffect(() => {
-    const getReservation = () => {
-      axios
-        .get(
-          process.env.REACT_APP_API_URL +
-            `/api/reservations/products/${itemId}/calendar?date1=${year}-${currentMonth}&date2=${year}-${nextMonth}`,
-        )
-        .then((res) => {
-          console.log('다음 달 예약 배열', res.data.reservationsDate2);
-          console.log(
-            '다음 달 예약 배열',
-            convertReservationDates(res.data.reservationsDate2),
-          );
-          dispatch(
-            setMonthlyReservation({
-              productTitle: res.data.productTitle,
-              baseFee: res.data.baseFee,
-              feePerDay: res.data.feePerDay,
-              minimumRentalPeriod: res.data.minimumRentalPeriod,
-              reservationsDate1: convertReservationDates(
-                res.data.reservationsDate1,
-              ),
-              reservationsDate2: convertReservationDates(
-                res.data.reservationsDate2,
-              ),
-            }),
-          );
-        })
-        .catch((err) => {
-          console.log(err);
-        });
-    };
-    getReservation();
-  }, [itemId]);
+    if (isError) {
+      console.log(error);
+    }
+
+    if (!isLoading && data) {
+      dispatch(setMonthlyReservation(data));
+    }
+  }, [isLoading, data, dispatch]);
+
   const monthlyReservation = useSelector(
     (state: RootState) => state.monthlyReservation,
   );
-  console.log('예약 정보', monthlyReservation);
+
   return (
     <BookingPageContainer>
       <BookingDates />
       <Calendars />
-      <ProductInfoTitle>
-        렌탈 상품명 : {monthlyReservation.productTitle}
-      </ProductInfoTitle>
-      <ProductInfoWrapper>
-        <ProductInfo>기본료 : {monthlyReservation.baseFee}원</ProductInfo>
-        <ProductInfo>1일 사용료 : {monthlyReservation.feePerDay}원</ProductInfo>
-        <ProductInfo>
-          최소 예약 기간 : {monthlyReservation.minimumRentalPeriod}일
-        </ProductInfo>
-      </ProductInfoWrapper>
+      <RentalProductInfo monthlyReservation={monthlyReservation} />
       <ReservationBtn
         minimumRentalPeriod={monthlyReservation.minimumRentalPeriod}
       />

--- a/client/src/pages/Detail/components/ChatBtn.tsx
+++ b/client/src/pages/Detail/components/ChatBtn.tsx
@@ -1,13 +1,10 @@
 import axios from 'axios';
-import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import useGetMe from '../../../common/utils/customHooks/useGetMe';
 import BigDefaultBtn from '../../../common/components/Button';
 import { colorPalette } from '../../../common/utils/enum/colorPalette';
 import { ACCESS_TOKEN } from '../../Login/constants';
 import { useMutation, useQuery } from 'react-query';
-import Loading from '../../../common/components/Loading';
-import ErrorPage from '../../../common/components/ErrorPage';
 import useDecryptToken from '../../../common/utils/customHooks/useDecryptToken';
 
 function makeChatRoomName(senderId: number, receiverId: number) {
@@ -178,5 +175,3 @@ function ChatBtn() {
   );
 }
 export default ChatBtn;
-
-//

--- a/client/src/pages/Detail/components/ItemContent.tsx
+++ b/client/src/pages/Detail/components/ItemContent.tsx
@@ -165,7 +165,7 @@ const ItemContent = () => {
                 >
                   예약하기
                 </BigDefaultBtn>
-                {/* <ChatBtn /> */}
+                <ChatBtn />
               </ItemActionBtn>
             </ItemUserWrapper>
           </ItemInfoWrapper>


### PR DESCRIPTION
### 기능 요약
[중복되는 로직들을 helper function으로 분리]
- 날짜 간 차이를 계산해주는 함수를 helper function으로 분리
- string type의 날짜를 object type으로 변환해주는 함수를 helper function으로 분리
- 액세스 토큰 암호화/복호화 로직을 custom hook이 아닌 helper function으로 분리 (순수함수이므로)
- 예약 시작 날짜와 예약 마감 날짜 사이에 기존 예약이 있는지 확인하는 함수를 helper function으로 분리

[custom hook으로 분리]
- 기존 예약 내역 GET 요청하는 함수를 custom hook으로 분리
- 유저가 클릭한 날짜를 POST 요청하는 함수를 custom hook으로 분리

### 배운점
helper function은 반드시 common 폴더에만 존재해야 한다고 생각했는데, page 별로 두는 방법도 있다는 것을 알게되었다. 앱 전역에서 사용하는 helper function이 아닐 경우 반드시 common 폴더에 둘 필요는 없다.
